### PR TITLE
Gestión de miembros y solicitudes de ingreso #5

### DIFF
--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -16,7 +16,7 @@ from app.modules.dataset.models import (
 from core.repositories.BaseRepository import BaseRepository
 
 from app import db
-from app.modules.auth.models import Community, community_request
+from app.modules.auth.models import Community, User, community_request
 
 logger = logging.getLogger(__name__)
 
@@ -179,3 +179,25 @@ class CommunityRepository:
                 )
             )
         db.session.commit()
+
+    @staticmethod
+    def add_member(community_id, user_id):
+        community = Community.query.get(community_id)
+        if community:
+            user = User.query.get(user_id)
+            if user and user not in community.members:
+                community.members.append(user)
+                db.session.commit()
+                return True
+        return False
+
+    @staticmethod
+    def remove_request(community_id, user_id):
+        community = Community.query.get(community_id)
+        if community:
+            user = User.query.get(user_id)
+            if user and user in community.requests:
+                community.requests.remove(user)
+                db.session.commit()
+                return True
+        return False

--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -16,7 +16,7 @@ from app.modules.dataset.models import (
 from core.repositories.BaseRepository import BaseRepository
 
 from app import db
-from app.modules.auth.models import Community
+from app.modules.auth.models import Community, community_request
 
 logger = logging.getLogger(__name__)
 
@@ -165,5 +165,17 @@ class CommunityRepository:
             db.session.commit()
 
     @staticmethod
-    def save_community(community):
+    def save_community():
+        db.session.commit()
+
+    @staticmethod
+    def request_community(community_id, current_user):
+        community = Community.query.get(community_id)
+        if community:
+            db.session.execute(
+                community_request.insert().values(
+                    community_id=community_id,
+                    user_id=current_user.id
+                )
+            )
         db.session.commit()

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -494,7 +494,7 @@ def view_community(community_id):
 
     owners = [owner.profile.name for owner in community.owners.all()]
     members = [member.profile.name for member in community.members.all()]
-    requests = [request.profile.name for request in community.requests.all()]
+    requests = community.requests.all()
 
     return render_template('community/view_community.html',
                            community=community,
@@ -572,3 +572,25 @@ def request_community(community_id):
     except Exception as e:
         flash(f'Error: {str(e)}', 'danger')
     return redirect(url_for('community.view_community', community_id=community_id))
+
+
+@community_bp.route('/community/<int:community_id>/requests/<int:user_id>/<string:action>', methods=['POST'])
+@login_required
+def handle_request(community_id, user_id, action):
+    community = CommunityService.get_community_by_id(community_id)
+    if not community or not CommunityService.is_owner(community, current_user):
+        flash('You do not have permission to perform this action.', 'danger')
+        return redirect(url_for('community.view_community', community_id=community_id))
+
+    if action not in ["accept", "reject"]:
+        flash('Invalid action.', 'danger')
+        return redirect(url_for('community.view_community', community_id=community_id))
+
+    success = CommunityService.handle_request(community_id, user_id, action)
+    if success:
+        flash('Request handled successfully.', 'success')
+    else:
+        flash('Failed to handle the request.', 'danger')
+
+    return redirect(url_for('community.view_community', community_id=community_id))
+

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -593,4 +593,3 @@ def handle_request(community_id, user_id, action):
         flash('Failed to handle the request.', 'danger')
 
     return redirect(url_for('community.view_community', community_id=community_id))
-

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -561,3 +561,14 @@ def delete_community(community_id):
         return "Forbidden", 403
     CommunityService.remove_community(community_id)
     return redirect(url_for('community.list_communities'))
+
+
+@community_bp.route('/community/<int:community_id>/request', methods=['POST'])
+@login_required
+def request_community(community_id):
+    try:
+        CommunityService.request_community(community_id, current_user)
+        flash('Request to join the community has been sent successfully.', 'success')
+    except Exception as e:
+        flash(f'Error: {str(e)}', 'danger')
+    return redirect(url_for('community.view_community', community_id=community_id))

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -239,7 +239,7 @@ class CommunityService:
         if not community:
             return None
         community.name = new_name
-        CommunityRepository.save_community(community)
+        CommunityRepository.save_community()
         return community
 
     @staticmethod
@@ -257,3 +257,14 @@ class CommunityService:
     @staticmethod
     def is_request(community, current_user):
         return current_user.id in [request.id for request in community.requests]
+
+    @staticmethod
+    def request_community(community_id, current_user):
+        community = CommunityService.get_community_by_id(community_id)
+        result_member = CommunityService.is_member(community, current_user)
+        if result_member:
+            raise Exception("User is already a member of this community.")
+        result_request = CommunityService.is_request(community, current_user)
+        if result_request:
+            raise Exception("Request to join the community is already pending.")
+        CommunityRepository.request_community(community_id, current_user)

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -268,3 +268,14 @@ class CommunityService:
         if result_request:
             raise Exception("Request to join the community is already pending.")
         CommunityRepository.request_community(community_id, current_user)
+
+    @staticmethod
+    def handle_request(community_id, user_id, action):
+        if action == "accept":
+            added = CommunityRepository.add_member(community_id, user_id)
+            if added:
+                CommunityRepository.remove_request(community_id, user_id)
+                return True
+        elif action == "reject":
+            return CommunityRepository.remove_request(community_id, user_id)
+        return False

--- a/app/modules/dataset/templates/community/view_community.html
+++ b/app/modules/dataset/templates/community/view_community.html
@@ -12,9 +12,11 @@
         {% if not is_member(community, current_user) %}
             {% if not is_request(community, current_user) %}
                 <div class="d-flex justify-content-end mb-3">
-                    <a href="{{ url_for('community.create_community') }}" class="btn btn-primary">
-                        <i data-feather="plus"></i> Request to join
-                    </a>
+                    <form method="POST" action="{{ url_for('community.request_community', community_id=community.id) }}" class="d-inline">
+                        <button type="submit" class="btn btn-primary" onclick="return confirm('Do you want to join this community?');">
+                            <i data-feather="user-plus"></i> Request to join
+                        </button>
+                    </form>    
                 </div>
             {% endif %}
         {% endif %}

--- a/app/modules/dataset/templates/community/view_community.html
+++ b/app/modules/dataset/templates/community/view_community.html
@@ -9,6 +9,16 @@
 <div class="card mb-3">
     <div class="card-body">
         <h5 class="card-title">Details</h5>
+        {% if not is_member(community, current_user) %}
+            {% if not is_request(community, current_user) %}
+                <div class="d-flex justify-content-end mb-3">
+                    <a href="{{ url_for('community.create_community') }}" class="btn btn-primary">
+                        <i data-feather="plus"></i> Request to join
+                    </a>
+                </div>
+            {% endif %}
+        {% endif %}
+
         <p><strong>Created At:</strong> {{ community.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</p>
         
         <p><strong>Owners:</strong> 

--- a/app/modules/dataset/templates/community/view_community.html
+++ b/app/modules/dataset/templates/community/view_community.html
@@ -41,13 +41,29 @@
 
         {% if is_owner(community, current_user) %}
             {% if requests %}
-                <p><strong>Requests:</strong> 
-                    {{ requests | join(', ') }}
-                </p>
+                <p><strong>Requests:</strong></p>
+                <ul>
+                    {% for request in requests %}
+                        <li>
+                            {{ request.profile.surname }}, {{ request.profile.name }}
+                            <form method="POST" action="{{ url_for('community.handle_request', community_id=community.id, user_id=request.id, action='accept') }}" style="display: inline;">
+                                <button type="submit" class="btn btn-success btn-sm">
+                                    <i data-feather="user-plus"></i>
+                                </button>
+                            </form>
+                            <form method="POST" action="{{ url_for('community.handle_request', community_id=community.id, user_id=request.id, action='reject') }}" style="display: inline;">
+                                <button type="submit" class="btn btn-danger btn-sm">
+                                    <i data-feather="user-x"></i>
+                                </button>                            
+                            </form>
+                        </li>
+                    {% endfor %}
+                </ul>
             {% else %}
                 <p>No requests yet.</p>
             {% endif %}
-        {% endif %}
+    {% endif %}
+
     </div>
 </div>
 


### PR DESCRIPTION
Esta PR implementa el sistema de solicitudes para unirse a comunidades, permitiendo a los usuarios solicitar unirse a comunidades y a los propietarios gestionar estas solicitudes.

Posibles pruebas:

- Solicitar unirse a una comunidad (como usuario no propietario): Verifica que un usuario pueda enviar una solicitud para unirse a una comunidad.
- No permitir que el propietario se solicite unirse a su propia comunidad: Verifica que el propietario no pueda solicitar unirse a su propia comunidad.
- Listar solicitudes pendientes para un propietario: Verifica que un propietario pueda ver las solicitudes pendientes de unirse a su comunidad.
- Aceptar una solicitud: Verifica que un propietario pueda aceptar una solicitud y añadir al usuario como miembro.
- Rechazar una solicitud: Verifica que un propietario pueda rechazar una solicitud y eliminarla.
- Ver miembros de una comunidad: Verifica que se puedan listar correctamente los miembros aprobados de una comunidad.
- Solo los propietarios pueden aprobar o rechazar solicitudes: Verifica que solo el propietario de una comunidad pueda aprobar o rechazar solicitudes.
- Solicitar unirse sin haber enviado una solicitud: Verifica que el sistema no permita enviar una solicitud si ya se es miembro o propietario.