### PR TITLE
Listar comunidades con búsqueda

### DIFF
--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -147,6 +147,11 @@ class CommunityRepository:
             .filter(community_members.c.user_id == current_user_id)
             .all()
         )
+        
+    @staticmethod
+    def search_by_name(query):
+        search = f"%{query}%"
+        return Community.query.filter(Community.name.ilike(search)).all()
 
     @staticmethod
     def get_community_by_name(name):

--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -147,7 +147,7 @@ class CommunityRepository:
             .filter(community_members.c.user_id == current_user_id)
             .all()
         )
-        
+
     @staticmethod
     def search_by_name(query):
         search = f"%{query}%"

--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -17,6 +17,7 @@ from core.repositories.BaseRepository import BaseRepository
 
 from app import db
 from app.modules.auth.models import Community
+from app.modules.auth.models import community_members
 
 logger = logging.getLogger(__name__)
 
@@ -137,6 +138,15 @@ class CommunityRepository:
     @staticmethod
     def get_community_by_id(community_id):
         return Community.query.get(community_id)
+
+    @staticmethod
+    def get_communities_by_member(current_user_id):
+        return (
+            Community.query
+            .join(community_members, community_members.c.community_id == Community.id)
+            .filter(community_members.c.user_id == current_user_id)
+            .all()
+        )
 
     @staticmethod
     def get_community_by_name(name):

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -477,7 +477,9 @@ community_service = CommunityService()
 @login_required
 def list_communities():
     communities = CommunityService.list_communities()
+    my_communities = CommunityService.get_communities_by_member(current_user)
     return render_template('community/list_communities.html',
+                           my_communities=my_communities,
                            communities=communities,
                            current_user=current_user,
                            is_owner=CommunityService.is_owner,

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -487,6 +487,17 @@ def list_communities():
                            is_request=CommunityService.is_request)
 
 
+@community_bp.route('/communities/search', methods=['GET'])
+@login_required
+def search_communities():
+    query = request.args.get('query', '').strip()
+    communities = CommunityService.search_communities(query)
+    return render_template('community/search_results.html',
+                           query=query,
+                           communities=communities,
+                           current_user=current_user)
+
+
 @community_bp.route('/community/<int:community_id>', methods=['GET'])
 @login_required
 def view_community(community_id):

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -230,7 +230,7 @@ class CommunityService:
     @staticmethod
     def get_communities_by_member(current_user):
         return CommunityRepository.get_communities_by_member(current_user.id)
-    
+
     @staticmethod
     def search_communities(query):
         if not query:

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -230,6 +230,12 @@ class CommunityService:
     @staticmethod
     def get_communities_by_member(current_user):
         return CommunityRepository.get_communities_by_member(current_user.id)
+    
+    @staticmethod
+    def search_communities(query):
+        if not query:
+            return []
+        return CommunityRepository.search_by_name(query)
 
     @staticmethod
     def create_community(name, current_user):

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -228,6 +228,10 @@ class CommunityService:
         return CommunityRepository.get_community_by_id(community_id)
 
     @staticmethod
+    def get_communities_by_member(current_user):
+        return CommunityRepository.get_communities_by_member(current_user.id)
+
+    @staticmethod
     def create_community(name, current_user):
         if CommunityRepository.get_community_by_name(name):
             abort(400, description="A community with this name already exists.")

--- a/app/modules/dataset/templates/community/list_communities.html
+++ b/app/modules/dataset/templates/community/list_communities.html
@@ -1,20 +1,29 @@
 {% extends "base_template.html" %}
 
-{% block title %}All Communities{% endblock %}
+{% block title %}My Communities{% endblock %}
 
 {% block content %}
 
-<h1 class="h3 mb-3">Communities</h1>
+<h1 class="h3 mb-3">My Communities</h1>
 
-<div class="d-flex justify-content-end mb-3">
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <!-- Formulario de búsqueda -->
+    <form method="GET" action="{{ url_for('community.search_communities') }}" class="d-flex w-50">
+        <input type="text" name="query" class="form-control me-2" placeholder="Search communities..." required style="width: 200px;">
+        <button type="submit" class="btn btn-primary" style="white-space: nowrap;">
+            <i data-feather="search"></i> Search
+        </button>
+    </form>
+    <!-- Botón para crear comunidad -->
     <a href="{{ url_for('community.create_community') }}" class="btn btn-primary">
         <i data-feather="plus"></i> Create Community
     </a>
 </div>
 
-<h2 class="h4">My Communities</h2>
-{% if my_communities %}
-    <div class="col-12 mb-4">
+<!-- Mis comunidades -->
+<div class="col-12 mb-4">
+    <h4>My Communities</h4>
+    {% if my_communities %}
         <div class="card">
             <div class="card-body">
                 <table class="table">
@@ -65,14 +74,15 @@
                 </table>
             </div>
         </div>
-    </div>
-{% else %}
-    <p>You are not a member of any communities.</p>
-{% endif %}
+    {% else %}
+        <p>You are not a member of any community.</p>
+    {% endif %}
+</div>
 
-<h2 class="h4">All Communities</h2>
-{% if communities %}
-    <div class="col-12">
+<!-- Todas las comunidades -->
+<div class="col-12">
+    <h4>All Communities</h4>
+    {% if communities %}
         <div class="card">
             <div class="card-body">
                 <table class="table">
@@ -80,6 +90,7 @@
                         <tr>
                             <th>Name</th>
                             <th>Role</th>
+                            <th>Options</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -101,15 +112,20 @@
                                         None
                                     {% endif %}
                                 </td>
+                                <td>
+                                    <a href="{{ url_for('community.view_community', community_id=community.id) }}">
+                                        <i data-feather="eye"></i>
+                                    </a>
+                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
                 </table>
             </div>
         </div>
-    </div>
-{% else %}
-    <p>No communities available. Try creating one!</p>
-{% endif %}
+    {% else %}
+        <p>No communities found.</p>
+    {% endif %}
+</div>
 
 {% endblock %}

--- a/app/modules/dataset/templates/community/list_communities.html
+++ b/app/modules/dataset/templates/community/list_communities.html
@@ -1,10 +1,10 @@
 {% extends "base_template.html" %}
 
-{% block title %}My Communities{% endblock %}
+{% block title %}All Communities{% endblock %}
 
 {% block content %}
 
-<h1 class="h3 mb-3">My Communities</h1>
+<h1 class="h3 mb-3">Communities</h1>
 
 <div class="d-flex justify-content-end mb-3">
     <a href="{{ url_for('community.create_community') }}" class="btn btn-primary">
@@ -12,6 +12,65 @@
     </a>
 </div>
 
+<h2 class="h4">My Communities</h2>
+{% if my_communities %}
+    <div class="col-12 mb-4">
+        <div class="card">
+            <div class="card-body">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Role</th>
+                            <th>Options</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for community in my_communities %}
+                            <tr>
+                                <td>
+                                    <a href="{{ url_for('community.view_community', community_id=community.id) }}">
+                                        {{ community.name }}
+                                    </a>
+                                </td>
+                                <td>
+                                    {% if is_owner(community, current_user) %}
+                                        Owner
+                                    {% elif is_member(community, current_user) %}
+                                        Member
+                                    {% elif is_request(community, current_user) %}
+                                        Request
+                                    {% else %}
+                                        None
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <a href="{{ url_for('community.view_community', community_id=community.id) }}">
+                                        <i data-feather="eye"></i>
+                                    </a>
+                                    {% if is_owner(community, current_user) %}
+                                        <a href="{{ url_for('community.edit_community', community_id=community.id) }}">
+                                            <i data-feather="edit"></i>
+                                        </a>
+                                        <form method="POST" action="{{ url_for('community.delete_community', community_id=community.id) }}" style="display: inline;">
+                                            <button type="submit" class="btn btn-link p-0 m-0 align-baseline text-danger" onclick="return confirm('Are you sure you want to delete this community?');">
+                                                <i data-feather="trash-2"></i>
+                                            </button>
+                                        </form>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% else %}
+    <p>You are not a member of any communities.</p>
+{% endif %}
+
+<h2 class="h4">All Communities</h2>
 {% if communities %}
     <div class="col-12">
         <div class="card">
@@ -21,7 +80,6 @@
                         <tr>
                             <th>Name</th>
                             <th>Role</th>
-                            <th>Options</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -43,21 +101,6 @@
                                         None
                                     {% endif %}
                                 </td>
-                                <td>
-                                        <a href="{{ url_for('community.view_community', community_id=community.id) }}">
-                                            <i data-feather="eye"></i>
-                                        </a>
-                                        {% if is_owner(community, current_user) %}
-                                            <a href="{{ url_for('community.edit_community', community_id=community.id) }}">
-                                                <i data-feather="edit"></i>
-                                            </a>
-                                            <form method="POST" action="{{ url_for('community.delete_community', community_id=community.id) }}" style="display: inline;">
-                                                <button type="submit" class="btn btn-link p-0 m-0 align-baseline text-danger" onclick="return confirm('Are you sure you want to delete this community?');">
-                                                    <i data-feather="trash-2"></i>
-                                                </button>
-                                            </form>
-                                        {% endif %}
-                                </td>
                             </tr>
                         {% endfor %}
                     </tbody>
@@ -66,18 +109,7 @@
         </div>
     </div>
 {% else %}
-    <div class="col-12 col-md-6">
-        <div class="card">
-            <div class="card-header">
-                <h5 class="card-title mb-0">No communities found</h5>
-            </div>
-            <div class="card-body">
-                <p class="card-text">
-                    There are no communities available, try creating one.
-                </p>
-            </div>
-        </div>
-    </div>
+    <p>No communities available. Try creating one!</p>
 {% endif %}
 
 {% endblock %}

--- a/app/modules/dataset/templates/community/search_results.html
+++ b/app/modules/dataset/templates/community/search_results.html
@@ -1,0 +1,57 @@
+{% extends "base_template.html" %}
+
+{% block title %}Search Results{% endblock %}
+
+{% block content %}
+
+<h1 class="h3 mb-3">Search Results for "{{ query }}"</h1>
+
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <a href="{{ url_for('community.list_communities') }}" class="btn btn-secondary me-3">
+        <i data-feather="arrow-left"></i> Back to All Communities
+    </a>
+    <form method="GET" action="{{ url_for('community.search_communities') }}" class="d-flex">
+        <input type="text" name="query" class="form-control me-2" placeholder="Search..." required style="width: 200px;">
+        <button type="submit" class="btn btn-primary" style="white-space: nowrap;">
+            <i data-feather="search"></i> Search Again
+        </button>
+    </form>
+</div>
+
+
+{% if communities %}
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Options</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for community in communities %}
+                            <tr>
+                                <td>
+                                    <a href="{{ url_for('community.view_community', community_id=community.id) }}">
+                                        {{ community.name }}
+                                    </a>
+                                </td>
+                                <td>
+                                    <a href="{{ url_for('community.view_community', community_id=community.id) }}">
+                                        <i data-feather="eye"></i>
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+{% else %}
+    <p>No communities found matching your search.</p>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
En el listado de comunidades, mostrar las comunidades de las que el usuario es miembro y el resto de comunidades para que sea accesible aún si no sabemos el nombre de la misma. Además, agregar una opción para buscar entre todas las comunidades con filtros relevantes.

¿Cómo probar que funciona correctamente?
-     Buscar una comunidad que exista.
-     Buscar una comunidad que no exista.
-     Buscar utilizando un término parcial del nombre de una comunidad.
-     Buscar dejando el campo vacío (debe bloquearse o mostrar un error).
-     Ver "Mis comunidades" correctamente listadas.
-     Ver "Todas las comunidades" correctamente listadas.
-     Hacer clic en "Search again" y realizar una nueva búsqueda.
-     Hacer clic en "Back to list" y volver al listado inicial.