### PR TITLE
Permitir agregar una comunidad al crear un dataset si eres dueño

### DIFF
--- a/app/modules/auth/seeders.py
+++ b/app/modules/auth/seeders.py
@@ -41,6 +41,9 @@ class AuthSeeder(BaseSeeder):
 
 
 class CommunitySeeder(BaseSeeder):
+
+    priority = 1
+
     def run(self):
         users = User.query.all()
 

--- a/app/modules/dataset/forms.py
+++ b/app/modules/dataset/forms.py
@@ -57,6 +57,7 @@ class FeatureModelForm(FlaskForm):
 class DataSetForm(FlaskForm):
     title = StringField("Title", validators=[DataRequired()])
     desc = TextAreaField("Description", validators=[DataRequired()])
+    community = SelectField("Community", coerce=int, validators=[Optional()])
     publication_type = SelectField(
         "Publication type",
         choices=[(pt.value, pt.name.replace("_", " ").title()) for pt in PublicationType],
@@ -81,6 +82,7 @@ class DataSetForm(FlaskForm):
             "publication_doi": self.publication_doi.data,
             "dataset_doi": self.dataset_doi.data,
             "tags": self.tags.data,
+            "community_id": self.community.data,
         }
 
     def convert_publication_type(self, value):

--- a/app/modules/dataset/models.py
+++ b/app/modules/dataset/models.py
@@ -78,6 +78,9 @@ class DataSet(db.Model):
     ds_meta_data = db.relationship('DSMetaData', backref=db.backref('data_set', uselist=False))
     feature_models = db.relationship('FeatureModel', backref='data_set', lazy=True, cascade="all, delete")
 
+    community_id = db.Column(db.Integer, db.ForeignKey('community.id'), nullable=True)
+    community = db.relationship('Community', backref='datasets')
+
     def name(self):
         return self.ds_meta_data.title
 

--- a/app/modules/dataset/models.py
+++ b/app/modules/dataset/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 
-from flask import request
+from flask import request, url_for
 from sqlalchemy import Enum as SQLAlchemyEnum
 
 from app import db
@@ -130,6 +130,10 @@ class DataSet(db.Model):
             'files_count': self.get_files_count(),
             'total_size_in_bytes': self.get_file_total_size(),
             'total_size_in_human_format': self.get_file_total_size_for_human(),
+            'community_name': self.community.name if self.community else None,
+            'community_id': self.community_id if self.community else None,
+            'community_url': url_for('community.view_community',
+                                     community_id=self.community_id, _external=True) if self.community else None
         }
 
     def __repr__(self):

--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -16,8 +16,7 @@ from app.modules.dataset.models import (
 from core.repositories.BaseRepository import BaseRepository
 
 from app import db
-from app.modules.auth.models import Community, User, community_request
-from app.modules.auth.models import community_members
+from app.modules.auth.models import Community, User, community_request, community_members, community_owners
 
 logger = logging.getLogger(__name__)
 
@@ -147,6 +146,14 @@ class CommunityRepository:
             .filter(community_members.c.user_id == current_user_id)
             .all()
         )
+
+    @staticmethod
+    def get_communities_by_owner(current_user_id):
+        return (
+            Community.query
+            .join(community_owners, community_owners.c.community_id == Community.id)
+            .filter(community_owners.c.user_id == current_user_id)
+            .all())
 
     @staticmethod
     def search_by_name(query):

--- a/app/modules/dataset/repositories.py
+++ b/app/modules/dataset/repositories.py
@@ -120,6 +120,9 @@ class DataSetRepository(BaseRepository):
     def get_all(self) -> list[DataSet]:
         return self.model.query.all()
 
+    def get_all_by_community(community_id):
+        return DataSet.query.filter_by(community_id=community_id)
+
 
 class DOIMappingRepository(BaseRepository):
     def __init__(self):

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -55,7 +55,10 @@ ds_view_record_service = DSViewRecordService()
 @dataset_bp.route("/dataset/upload", methods=["GET", "POST"])
 @login_required
 def create_dataset():
+    communities = community_service.get_communities_by_owner(current_user)    
+
     form = DataSetForm()
+    form.community.choices = [(c.id, c.name) for c in communities]
     if request.method == "POST":
 
         dataset = None

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -576,6 +576,9 @@ def view_community(community_id):
     owners = [owner.profile.name for owner in community.owners.all()]
     members = [member.profile.name for member in community.members.all()]
     requests = community.requests.all()
+    datasets = DataSetService.get_all_by_community(community_id=community_id)
+
+    print(datasets[0].created_at)
 
     return render_template('community/view_community.html',
                            community=community,
@@ -583,6 +586,7 @@ def view_community(community_id):
                            owners=owners,
                            members=members,
                            requests=requests,
+                           datasets=datasets,
                            is_owner=CommunityService.is_owner,
                            is_member=CommunityService.is_member,
                            is_request=CommunityService.is_request)

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -55,7 +55,7 @@ ds_view_record_service = DSViewRecordService()
 @dataset_bp.route("/dataset/upload", methods=["GET", "POST"])
 @login_required
 def create_dataset():
-    communities = community_service.get_communities_by_owner(current_user)    
+    communities = community_service.get_communities_by_owner(current_user)
 
     form = DataSetForm()
     form.community.choices = [(c.id, c.name) for c in communities]

--- a/app/modules/dataset/seeders.py
+++ b/app/modules/dataset/seeders.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-from app.modules.auth.models import User
+from app.modules.auth.models import Community, User
 from app.modules.featuremodel.models import FMMetaData, FeatureModel
 from app.modules.hubfile.models import Hubfile
 from core.seeders.BaseSeeder import BaseSeeder
@@ -56,11 +56,20 @@ class DataSetSeeder(BaseSeeder):
         ]
         self.seed(authors)
 
-        # Create DataSet instances
+        # Retrieve communities
+        community1 = Community.query.filter_by(name='Data Science Enthusiasts').first()
+        community2 = Community.query.filter_by(name='AI Researchers').first()
+        community3 = Community.query.filter_by(name='Python Developers').first()
+
+        if not community1 or not community2 or not community3:
+            raise Exception("Communities not found. Please seed communities first.")
+
+        # Create DataSet instances and assign communities
         datasets = [
             DataSet(
                 user_id=user1.id if i % 2 == 0 else user2.id,
                 ds_meta_data_id=seeded_ds_meta_data[i].id,
+                community_id=community1.id if i % 3 == 0 else community2.id if i % 3 == 1 else community3.id,
                 created_at=datetime.now(timezone.utc)
             ) for i in range(4)
         ]

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -109,7 +109,7 @@ class DataSetService(BaseService):
                 author = self.author_repository.create(commit=False, ds_meta_data_id=dsmetadata.id, **author_data)
                 dsmetadata.authors.append(author)
 
-            dataset = self.create(commit=False, 
+            dataset = self.create(commit=False,
                                   user_id=current_user.id,
                                   ds_meta_data_id=dsmetadata.id,
                                   community_id=form.community.data if form.community.data else None,)

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -96,6 +96,9 @@ class DataSetService(BaseService):
     def get_all(self) -> list[DataSet]:
         return self.repository.get_all()
 
+    def get_all_by_community(community_id):
+        return DataSetRepository.get_all_by_community(community_id=community_id)
+
     def create_from_form(self, form, current_user) -> DataSet:
         main_author = {
             "name": f"{current_user.profile.surname}, {current_user.profile.name}",

--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -109,7 +109,10 @@ class DataSetService(BaseService):
                 author = self.author_repository.create(commit=False, ds_meta_data_id=dsmetadata.id, **author_data)
                 dsmetadata.authors.append(author)
 
-            dataset = self.create(commit=False, user_id=current_user.id, ds_meta_data_id=dsmetadata.id)
+            dataset = self.create(commit=False, 
+                                  user_id=current_user.id,
+                                  ds_meta_data_id=dsmetadata.id,
+                                  community_id=form.community.data if form.community.data else None,)
 
             for feature_model in form.feature_models:
                 uvl_filename = feature_model.uvl_filename.data
@@ -230,6 +233,10 @@ class CommunityService:
     @staticmethod
     def get_communities_by_member(current_user):
         return CommunityRepository.get_communities_by_member(current_user.id)
+
+    @staticmethod
+    def get_communities_by_owner(current_user):
+        return CommunityRepository.get_communities_by_owner(current_user.id)
 
     @staticmethod
     def search_communities(query):

--- a/app/modules/dataset/templates/community/view_community.html
+++ b/app/modules/dataset/templates/community/view_community.html
@@ -87,6 +87,74 @@
             </button>
         </form>
     {% endif %}
+    
+    {% if datasets %}
+        <div class="mt-3">
+            {% for dataset in datasets %}
+            <div class="card mb-3">
+                <div class="card-body">
+                    <div class="d-flex align-items-center justify-content-between">
+                        <h5><b>{{ dataset.ds_meta_data.title }}</b></h5>
+                    </div>
+                    <div>
+                        {% if dataset.ds_meta_data.dataset_doi %}
+                            <h5><b><a href="{{ dataset.get_uvlhub_doi() }}">{{ dataset.ds_meta_data.title }}</a></b></h5>
+                        {% else %}
+                            <h5><b><a href="{{ url_for('dataset.get_unsynchronized_dataset', dataset_id=dataset.id) }}">{{ dataset.ds_meta_data.title }}</a></b></h5>
+                        {% endif %}
+                    </div>
+                    <p class="text-secondary">{{ dataset.created_at.strftime('%B %d, %Y at %I:%M %p') }}</p>
+
+                    <div class="row mb-4">
+                        <div class="col-md-4 col-12">
+                            <span class="text-secondary">
+                                Description
+                            </span>
+                        </div>
+                        <div class="col-md-8 col-12">
+                            <p class="card-text">{{ dataset.ds_meta_data.description }}</p>
+                        </div>
+                    </div>
+
+                    <div class="row mb-2">
+                        <div class="col-md-4 col-12">
+                            <span class="text-secondary">
+                                Authors
+                            </span>
+                        </div>
+                        <div class="col-md-8 col-12">
+                            {% for author in dataset.ds_meta_data.authors %}
+                                <p class="p-0 m-0">
+                                    {{ author.name }}
+                                    {% if author.affiliation %}
+                                        ({{ author.affiliation }})
+                                    {% endif %}
+                                    {% if author.orcid %}
+                                        ({{ author.orcid }})
+                                    {% endif %}
+                                </p>
+                            {% endfor %}
+                        </div>
+                    </div>
+
+                    <div class="row mb-2">
+                        <div class="col-md-4 col-12">
+                            <span class="text-secondary">
+                                Tags
+                            </span>
+                        </div>
+                        <div class="col-md-8 col-12">
+                            {% for tag in dataset.ds_meta_data.tags.split(',') %}
+                                <span class="badge bg-secondary">{{ tag.strip() }}</span>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+
 </div>
 
 {% endblock %}

--- a/app/modules/dataset/templates/dataset/upload_dataset.html
+++ b/app/modules/dataset/templates/dataset/upload_dataset.html
@@ -146,6 +146,16 @@
                                        disabled value="{{ current_user.profile.orcid }}">
                             </div>
 
+                            <div class="col-lg-6 col-12 mb-3">
+                                <label class="form-label">Select Community (Optional)</label>
+                                <select class="form-control" name="community">
+                                    <option value="">No Community</option>
+                                    {% for community_id, community_name in form.community.choices %}
+                                        <option value="{{ community_id }}">{{ community_name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+
                             <div class="col-12">
 
                                 <div class="mb-3">
@@ -190,6 +200,20 @@
                             </div>
 
 
+                        </div>
+
+                        <h1 class="h3 mb-3 mt-4">
+                            Community
+                        </h1>
+
+                        <div class="col-lg-6 col-12 mb-3">
+                            <label class="form-label">Select Community (Optional)</label>
+                            <select class="form-control" name="community">
+                                <option value="">No Community</option>
+                                {% for community_id, community_name in form.community.choices %}
+                                    <option value="{{ community_id }}">{{ community_name }}</option>
+                                {% endfor %}
+                            </select>
                         </div>
 
                     </div>

--- a/app/modules/dataset/templates/dataset/upload_dataset.html
+++ b/app/modules/dataset/templates/dataset/upload_dataset.html
@@ -146,16 +146,6 @@
                                        disabled value="{{ current_user.profile.orcid }}">
                             </div>
 
-                            <div class="col-lg-6 col-12 mb-3">
-                                <label class="form-label">Select Community (Optional)</label>
-                                <select class="form-control" name="community">
-                                    <option value="">No Community</option>
-                                    {% for community_id, community_name in form.community.choices %}
-                                        <option value="{{ community_id }}">{{ community_name }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-
                             <div class="col-12">
 
                                 <div class="mb-3">

--- a/app/modules/dataset/templates/dataset/view_dataset.html
+++ b/app/modules/dataset/templates/dataset/view_dataset.html
@@ -93,6 +93,20 @@
 
                 </div>
 
+                {% if dataset.community %}
+                <div class="row mb-2">
+                    <div class="col-md-4 col-12">
+                        <span class="text-secondary">Community</span>
+                    </div>
+                    <div class="col-md-8 col-12">
+                        <a href="{{ url_for('community.view_community', community_id=dataset.community.id) }}">
+                            <span>{{ dataset.community.name }}</span>
+                        </a>
+                    </div>
+                    
+                </div>
+                {% endif %}
+
                 {% if dataset.ds_meta_data.publication_doi %}
                 <div class="row mb-2">
                     <div class="col-md-4 col-12">

--- a/app/modules/explore/assets/scripts.js
+++ b/app/modules/explore/assets/scripts.js
@@ -58,6 +58,7 @@ function send_query() {
 
 
                     data.forEach(dataset => {
+                        console.log(dataset.url)
                         let card = document.createElement('div');
                         card.className = 'col-12';
                         card.innerHTML = `
@@ -96,8 +97,21 @@ function send_query() {
                                                 <p class="p-0 m-0">${author.name}${author.affiliation ? ` (${author.affiliation})` : ''}${author.orcid ? ` (${author.orcid})` : ''}</p>
                                             `).join('')}
                                         </div>
-
                                     </div>
+
+                                    ${dataset.community_id ? `
+                                    <div class="row mb-2">
+                                        <div class="col-md-4 col-12">
+                                            <span class="text-secondary">
+                                                Community
+                                            </span>
+                                        </div>
+                                        <div class="col-md-8 col-12">
+                                            <a href="${dataset.community_url}">
+                                                ${dataset.community_name}
+                                            </a>
+                                        </div>
+                                    </div>`: ''}
 
                                     <div class="row mb-2">
 


### PR DESCRIPTION
Esta PR implementa la funcionalidad para asociar datasets con comunidades, permitiendo a los usuarios seleccionar comunidades de las que son dueños al subir un dataset. Además, se asegura de que solo los usuarios con permisos adecuados puedan asociar datasets y muestra la información de la comunidad tanto en el dataset como en la página de la comunidad.

Para probar los cambios introducidos:

- Asociar una comunidad a un dataset (como usuario dueño)
- Mostrar todos los datasets asociados a una comunidad
- Mostrar la comunidad en el dataset si tiene una asociada tanto en el view del dataset como en el explore
