### PR TITLE
fix(explore): Arreglar límite superior del filtro de fecha de creación

### DIFF
--- a/app/modules/explore/repositories.py
+++ b/app/modules/explore/repositories.py
@@ -23,7 +23,7 @@ class ExploreRepository(BaseRepository):
             query = query.filter(DataSet.created_at >= min_creation_date)
         if max_creation_date:
             max_creation_date = (dt.strptime(max_creation_date, format).date() + timedelta(days=1)).strftime(format)
-            query = query.filter(DataSet.created_at <= max_creation_date)
+            query = query.filter(DataSet.created_at < max_creation_date)
         # DSMetrics
         if min_features:
             query = query.filter(DSMetrics.number_of_features >= int(min_features))


### PR DESCRIPTION
### **User description**
El bug se arregló haciendo que compare la fecha de los datasets y la fecha límite (+ 1 día) con _menor que_ en vez de _igual o menor que_. Ahora los datasets creados exactamente a las 00:00 del día siguiente al establecido en el filtro de fecha de creación máxima, ya no aparecerán.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a bug in the dataset creation date filter where datasets created exactly at midnight (00:00) of the day after the maximum date were incorrectly included in the results
- Changed the comparison operator from less than or equal to (<=) to strictly less than (<) when filtering by maximum creation date
- Ensures more accurate date range filtering by excluding the edge case of midnight on the following day



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repositories.py</strong><dd><code>Fix dataset creation date filter upper bound logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/explore/repositories.py

<li>Changed the comparison operator from '<=' to '<' in the <br>max_creation_date filter to fix edge case where datasets created at <br>midnight were incorrectly included<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/63/files#diff-8978d8e3fe7340c64583c5e31168939913638571b64293e260d114f7fc951341">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information