### PR TITLE
Arreglar botón de vaciar filtros

### DIFF
--- a/app/modules/explore/assets/scripts.js
+++ b/app/modules/explore/assets/scripts.js
@@ -201,6 +201,13 @@ function clearFilters() {
         // option.dispatchEvent(new Event('input', {bubbles: true}));
     });
 
+    // Reset the adavanced option
+    let advancedOptions = document.querySelectorAll(
+        '#min_creation_date, #max_creation_date, #min_size, #max_size, #min_models, #max_models, #min_features, #max_features');
+    advancedOptions.forEach(option => {
+        option.value = ""; 
+    });
+
     // Perform a new search with the reset filters
     queryInput.dispatchEvent(new Event('input', {bubbles: true}));
 }


### PR DESCRIPTION
### **User description**
El botón "Clear filters" de la pantalla explore ahora vacía todos los filtros, incluyendo los nuevos del work item Advanced filtering.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the "Clear filters" button functionality in the explore screen to properly reset all filter options
- Added support for clearing advanced work item filters including:
  - Creation date range (min/max)
  - Size range (min/max)
  - Models count range (min/max)
  - Features count range (min/max)



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scripts.js</strong><dd><code>Fix Clear Filters Button to Include Advanced Options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/explore/assets/scripts.js

<li>Added functionality to clear advanced filtering options in the <br><code>clearFilters()</code> function<br> <li> Reset values for creation date, size, models, and features range <br>filters<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/64/files#diff-3321c76be6a6ee4de1e246c0ddfe9b6cb87030339d51757a46778fbaa179c750">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information