### PR TITLE
DSMetrics no se calcula correctamente con archivos que usa espacios

### DIFF
--- a/app/modules/dataset/services.py
+++ b/app/modules/dataset/services.py
@@ -48,6 +48,7 @@ def calculate_features(file_path):
             if line == '\n':
                 # Breakpoint
                 return odd_tabs_lines
+            line = line.replace(' '*4, '\t')
             n_tabs = len(line) - len(line.lstrip('\t'))
             if (n_tabs % 2 == 1):
                 odd_tabs_lines += 1


### PR DESCRIPTION
### **User description**
Ahora antes de calcular el número de features, en cada línea se reemplazan los substrings de 4 espacios con tabuladores.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed bug in feature counting logic where files using spaces for indentation weren't being processed correctly
- Added preprocessing step to convert sequences of 4 spaces to tab characters before counting indentation levels
- Ensures consistent feature counting regardless of whether spaces or tabs are used for indentation



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>services.py</strong><dd><code>Fix feature counting for space-indented files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/dataset/services.py

<li>Added line to replace sequences of 4 spaces with tab characters before <br>counting features<br> <li> Fixes bug where features weren't being counted correctly in files <br>using spaces for indentation<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/71/files#diff-7d6aad78882e474cb8e88532d4d041704b1fadf585be91f1d8e6867511743aef">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information