### PR TITLE
Error en los formatos de descarga en el download all

### DIFF
--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -784,16 +784,18 @@ def view_community(community_id):
         is_member=CommunityService.is_member,
         is_request=CommunityService.is_request,
     )
-    return render_template('community/view_community.html',
-                           community=community,
-                           current_user=current_user,
-                           owners=owners,
-                           members=members,
-                           requests=requests,
-                           datasets=datasets,
-                           is_owner=CommunityService.is_owner,
-                           is_member=CommunityService.is_member,
-                           is_request=CommunityService.is_request)
+    return render_template(
+        "community/view_community.html",
+        community=community,
+        current_user=current_user,
+        owners=owners,
+        members=members,
+        requests=requests,
+        datasets=datasets,
+        is_owner=CommunityService.is_owner,
+        is_member=CommunityService.is_member,
+        is_request=CommunityService.is_request,
+    )
 
 
 @community_bp.route("/community/create", methods=["GET"])
@@ -863,7 +865,7 @@ def request_community(community_id):
     return redirect(url_for("community.view_community", community_id=community_id))
 
 
-@community_bp.route('/community/<int:community_id>/leave', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/leave", methods=["POST"])
 @login_required
 def leave_community(community_id):
     community = CommunityService.get_community_by_id(community_id)
@@ -878,10 +880,10 @@ def leave_community(community_id):
 
     CommunityService.remove_member(community_id, current_user)
     flash("You have left the community successfully.", "success")
-    return redirect(url_for('community.list_communities'))
+    return redirect(url_for("community.list_communities"))
 
 
-@community_bp.route('/community/<int:community_id>/requests/<int:user_id>/<string:action>', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/requests/<int:user_id>/<string:action>", methods=["POST"])
 @login_required
 def handle_request(community_id, user_id, action):
     community = CommunityService.get_community_by_id(community_id)

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -37,7 +37,7 @@ from app.modules.dataset.services import (
     DOIMappingService,
     CommunityService
 )
-from flamapy.metamodels.fm_metamodel.transformations import UVLReader, GlencoeWriter, SPLOTWriter, JSONWriter, AFMWriter
+from flamapy.metamodels.fm_metamodel.transformations import UVLReader, GlencoeWriter, SPLOTWriter
 from flamapy.metamodels.pysat_metamodel.transformations import FmToPysat, DimacsWriter
 from app.modules.hubfile.services import HubfileService
 from app.modules.zenodo.services import ZenodoService
@@ -644,7 +644,7 @@ def download_all_dataset():
                         continue
 
                     # Convertir cada archivo a los formatos deseados
-                    for format in ["glencoe", "dimacs", "splot", "json", "afm", "uvl"]:
+                    for format in ["glencoe", "dimacs", "splot", "uvl"]:
                         content = ""
                         name = f"{hubfile.name}_{format}.txt"
 
@@ -671,24 +671,10 @@ def download_all_dataset():
                             with open(temp_file.name, "r") as new_format_file:
                                 content = new_format_file.read()
                             name = f"{hubfile.name}_splot.txt"
-                        elif format == "json":
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
-                            fm = UVLReader(hubfile.get_path()).transform()
-                            JSONWriter(temp_file.name, fm).transform()
-                            with open(temp_file.name, "r") as new_format_file:
-                                content = new_format_file.read()
-                            name = f"{hubfile.name}_json.txt"
-                        elif format == "afm":
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.afm', delete=False)
-                            fm = UVLReader(hubfile.get_path()).transform()
-                            AFMWriter(temp_file.name, fm).transform()
-                            with open(temp_file.name, "r") as new_format_file:
-                                content = new_format_file.read()
-                            name = f"{hubfile.name}_afm.txt"
                         elif format == "uvl":
                             # Para UVL no hacemos transformación adicional, solo agregamos el archivo original
                             content = open(full_path, "r").read()
-                            name = f"{file.name}_uvl.txt"
+                            name = f"{file.name}"
 
                         # Agregar el archivo convertido al ZIP en la carpeta correspondiente al dataset
                         zipf.writestr(os.path.join(dataset_folder, name), content)

--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -24,9 +24,7 @@ from flask_login import login_required, current_user
 import requests
 
 from app.modules.dataset.forms import DataSetForm
-from app.modules.dataset.models import (
-    DSDownloadRecord
-)
+from app.modules.dataset.models import DSDownloadRecord
 from app.modules.dataset import dataset_bp
 from app.modules.dataset.services import (
     AuthorService,
@@ -35,7 +33,7 @@ from app.modules.dataset.services import (
     DSViewRecordService,
     DataSetService,
     DOIMappingService,
-    CommunityService
+    CommunityService,
 )
 from flamapy.metamodels.fm_metamodel.transformations import UVLReader, GlencoeWriter, SPLOTWriter
 from flamapy.metamodels.pysat_metamodel.transformations import FmToPysat, DimacsWriter
@@ -89,17 +87,13 @@ def create_dataset():
             except Exception as exc:
                 data = {}
                 fakenodo_response_json = {}
-                logger.exception(
-                    f"Exception while creating dataset in Zenodo: {exc}"
-                )
+                logger.exception(f"Exception while creating dataset in Zenodo: {exc}")
 
             if data.get("conceptrecid"):
                 deposition_id = data.get("id")
 
                 # Update dataset with deposition id in Fakenodo
-                dataset_service.update_dsmetadata(
-                    dataset.ds_meta_data_id, deposition_id=deposition_id
-                )
+                dataset_service.update_dsmetadata(dataset.ds_meta_data_id, deposition_id=deposition_id)
 
                 try:
                     # Iterate for each feature model (one feature model = one request to Fakenodo)
@@ -111,14 +105,9 @@ def create_dataset():
 
                     # Update DOI
                     deposition_doi = fakenodo_service.get_doi(deposition_id)
-                    dataset_service.update_dsmetadata(
-                        dataset.ds_meta_data_id, dataset_doi=deposition_doi
-                    )
+                    dataset_service.update_dsmetadata(dataset.ds_meta_data_id, dataset_doi=deposition_doi)
                 except Exception as e:
-                    msg = (
-                        f"It has not been possible to upload feature models in "
-                        f"Fakenodo and update the DOI: {e}"
-                    )
+                    msg = f"It has not been possible to upload feature models in " f"Fakenodo and update the DOI: {e}"
                     return jsonify({"message": msg}), 200
         else:
             try:
@@ -128,17 +117,13 @@ def create_dataset():
             except Exception as exc:
                 data = {}
                 zenodo_response_json = {}
-                logger.exception(
-                    f"Exception while creating dataset in Zenodo: {exc}"
-                )
+                logger.exception(f"Exception while creating dataset in Zenodo: {exc}")
 
             if data.get("conceptrecid"):
                 deposition_id = data.get("id")
 
                 # Update dataset with deposition id in Zenodo
-                dataset_service.update_dsmetadata(
-                    dataset.ds_meta_data_id, deposition_id=deposition_id
-                )
+                dataset_service.update_dsmetadata(dataset.ds_meta_data_id, deposition_id=deposition_id)
 
                 try:
                     # Iterate for each feature model (one feature model = one request to Zenodo)
@@ -150,14 +135,9 @@ def create_dataset():
 
                     # Update DOI
                     deposition_doi = zenodo_service.get_doi(deposition_id)
-                    dataset_service.update_dsmetadata(
-                        dataset.ds_meta_data_id, dataset_doi=deposition_doi
-                    )
+                    dataset_service.update_dsmetadata(dataset.ds_meta_data_id, dataset_doi=deposition_doi)
                 except Exception as e:
-                    msg = (
-                        f"It has not been possible to upload feature models in "
-                        f"Zenodo and update the DOI: {e}"
-                    )
+                    msg = f"It has not been possible to upload feature models in " f"Zenodo and update the DOI: {e}"
                     return jsonify({"message": msg}), 200
 
         # Delete temp folder
@@ -201,9 +181,7 @@ def upload():
         # Generate unique filename (by recursion)
         base_name, extension = os.path.splitext(file.filename)
         i = 1
-        while os.path.exists(
-            os.path.join(temp_folder, f"{base_name} ({i}){extension}")
-        ):
+        while os.path.exists(os.path.join(temp_folder, f"{base_name} ({i}){extension}")):
             i += 1
         new_filename = f"{base_name} ({i}){extension}"
         file_path = os.path.join(temp_folder, new_filename)
@@ -229,12 +207,12 @@ def upload():
 @dataset_bp.route("/dataset/file/upload/github", methods=["POST", "GET"])
 @login_required
 def upload_from_github():
-    github_url = request.json.get('url')
+    github_url = request.json.get("url")
     if not github_url:
         return jsonify({"error": "GitHub URL is required"}), 400
 
     # Cambiar la URL a la versión raw
-    if 'github.com' in github_url:
+    if "github.com" in github_url:
         raw_url = github_url.replace("github.com", "raw.githubusercontent.com").replace("/blob/", "/")
     else:
         return jsonify({"error": "Invalid GitHub URL"}), 400
@@ -244,9 +222,9 @@ def upload_from_github():
         response = requests.get(raw_url, timeout=15)
         response.raise_for_status()  # Si la respuesta es mala (404, 500), lanza una excepción
 
-        file_name = raw_url.split('/')[-1]
-        file_type = response.headers['Content-Type']
-        file_size = response.headers['Content-Length']
+        file_name = raw_url.split("/")[-1]
+        file_type = response.headers["Content-Type"]
+        file_size = response.headers["Content-Length"]
 
         # Obtener la carpeta temporal específica para el usuario actual
         temp_folder = current_user.temp_folder()
@@ -268,15 +246,15 @@ def upload_from_github():
             file_path = os.path.join(temp_folder, file_name)
 
         # Guardar el archivo descargado en la carpeta temporal
-        with open(file_path, 'wb') as temp_file:
+        with open(file_path, "wb") as temp_file:
             temp_file.write(response.content)
 
         # Procesar si es un ZIP
-        if file_name.endswith('.zip'):
+        if file_name.endswith(".zip"):
             extracted_files = []
-            with zipfile.ZipFile(file_path, 'r') as zip_ref:
+            with zipfile.ZipFile(file_path, "r") as zip_ref:
                 for zip_info in zip_ref.infolist():
-                    if zip_info.filename.endswith('.uvl'):  # Excluir directorios
+                    if zip_info.filename.endswith(".uvl"):  # Excluir directorios
                         extracted_filename = os.path.basename(zip_info.filename)
                         extracted_path = os.path.join(temp_folder, extracted_filename)
 
@@ -286,32 +264,36 @@ def upload_from_github():
                             extracted_path = os.path.join(temp_folder, f"{base_name} ({i}){extension}")
                             i += 1
 
-                        with zip_ref.open(zip_info) as source, open(extracted_path, 'wb') as target:
+                        with zip_ref.open(zip_info) as source, open(extracted_path, "wb") as target:
                             target.write(source.read())
 
-                    # Agregar el nombre del archivo extraído a la lista de archivos
+                        # Agregar el nombre del archivo extraído a la lista de archivos
                         extracted_files.append(extracted_filename)
 
-            return jsonify({
-                "message": "ZIP file uploaded and extracted successfully",
-                "fileName": file_name,
-                "fileType": file_type,
-                "extracted_files": extracted_files,
-                "fileSize": file_size
-            })
+            return jsonify(
+                {
+                    "message": "ZIP file uploaded and extracted successfully",
+                    "fileName": file_name,
+                    "fileType": file_type,
+                    "extracted_files": extracted_files,
+                    "fileSize": file_size,
+                }
+            )
 
         # Si el archivo es un uvl o cualquier otro archivo que no sea zip
-        elif file_name.endswith('.uvl'):
+        elif file_name.endswith(".uvl"):
             uvl_file_path = os.path.join(temp_folder, file_name)
-            with open(uvl_file_path, 'wb') as uvl_file:
+            with open(uvl_file_path, "wb") as uvl_file:
                 uvl_file.write(response.content)
 
-            return jsonify({
-                "message": "UVL file uploaded and validated successfully",
-                "fileName": file_name,
-                "filePath": uvl_file_path,  # Ruta del archivo UVL
-                "fileSize": file_size
-            })
+            return jsonify(
+                {
+                    "message": "UVL file uploaded and validated successfully",
+                    "fileName": file_name,
+                    "filePath": uvl_file_path,  # Ruta del archivo UVL
+                    "fileSize": file_size,
+                }
+            )
 
         else:
             return jsonify({"error": "Unsupported file type"}), 400
@@ -340,9 +322,7 @@ def upload_from_zip():
     if os.path.exists(file_path):
         base_name, extension = os.path.splitext(file.filename)
         i = 1
-        while os.path.exists(
-            os.path.join(temp_folder, f"{base_name} ({i}){extension}")
-        ):
+        while os.path.exists(os.path.join(temp_folder, f"{base_name} ({i}){extension}")):
             i += 1
         new_filename = f"{base_name} ({i}){extension}"
         file_path = os.path.join(temp_folder, new_filename)
@@ -357,7 +337,7 @@ def upload_from_zip():
     # Extraer archivos .uvl del zip
     extracted_files = []
     try:
-        with ZipFile(file_path, 'r') as zip_ref:
+        with ZipFile(file_path, "r") as zip_ref:
             for zip_info in zip_ref.infolist():
                 if zip_info.filename.endswith(".uvl"):
                     extracted_filename = os.path.basename(zip_info.filename)
@@ -371,7 +351,7 @@ def upload_from_zip():
                         i += 1
 
                     # Extraer el archivo y guardarlo en temp_folder
-                    with zip_ref.open(zip_info) as source, open(extracted_path, 'wb') as target:
+                    with zip_ref.open(zip_info) as source, open(extracted_path, "wb") as target:
                         target.write(source.read())
 
                     # Agregar el nombre del archivo extraído a la lista de archivos
@@ -554,16 +534,12 @@ def download_dataset(dataset_id):
 
                 zipf.write(
                     full_path,
-                    arcname=os.path.join(
-                        os.path.basename(zip_path[:-4]), relative_path
-                    ),
+                    arcname=os.path.join(os.path.basename(zip_path[:-4]), relative_path),
                 )
 
     user_cookie = request.cookies.get("download_cookie")
     if not user_cookie:
-        user_cookie = str(
-            uuid.uuid4()
-        )  # Generate a new unique identifier if it does not exist
+        user_cookie = str(uuid.uuid4())  # Generate a new unique identifier if it does not exist
         # Save the cookie to the user's browser
         resp = make_response(
             send_from_directory(
@@ -586,7 +562,7 @@ def download_dataset(dataset_id):
     existing_record = DSDownloadRecord.query.filter_by(
         user_id=current_user.id if current_user.is_authenticated else None,
         dataset_id=dataset_id,
-        download_cookie=user_cookie
+        download_cookie=user_cookie,
     ).first()
 
     if not existing_record:
@@ -650,14 +626,14 @@ def download_all_dataset():
 
                         # Realizar la conversión según el formato
                         if format == "glencoe":
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
                             fm = UVLReader(hubfile.get_path()).transform()
                             GlencoeWriter(temp_file.name, fm).transform()
                             with open(temp_file.name, "r") as new_format_file:
                                 content = new_format_file.read()
                             name = f"{hubfile.name}_glencoe.txt"
                         elif format == "dimacs":
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.cnf', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".cnf", delete=False)
                             fm = UVLReader(hubfile.get_path()).transform()
                             sat = FmToPysat(fm).transform()
                             DimacsWriter(temp_file.name, sat).transform()
@@ -665,7 +641,7 @@ def download_all_dataset():
                                 content = new_format_file.read()
                             name = f"{hubfile.name}_cnf.txt"
                         elif format == "splot":
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.splx', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".splx", delete=False)
                             fm = UVLReader(hubfile.get_path()).transform()
                             SPLOTWriter(temp_file.name, fm).transform()
                             with open(temp_file.name, "r") as new_format_file:
@@ -686,18 +662,11 @@ def download_all_dataset():
     # Si no se agregaron archivos al ZIP, devolvemos un mensaje de error, pero no un JSON.
     if not files_added:
         # El archivo ZIP no se crea si no se agregan archivos, solo respondemos con un mensaje.
-        return make_response(
-            jsonify({"error": "No se encontraron archivos disponibles para descargar"}), 404
-        )
+        return make_response(jsonify({"error": "No se encontraron archivos disponibles para descargar"}), 404)
 
     # Responder con el archivo ZIP
     resp = make_response(
-        send_from_directory(
-            temp_dir,
-            "all_datasets.zip",
-            as_attachment=True,
-            mimetype="application/zip"
-        )
+        send_from_directory(temp_dir, "all_datasets.zip", as_attachment=True, mimetype="application/zip")
     )
 
     # Establecer la cookie "download_cookie" para que no se genere nuevamente
@@ -705,8 +674,7 @@ def download_all_dataset():
 
     # Registrar la descarga en la base de datos
     existing_record = DSDownloadRecord.query.filter_by(
-        user_id=current_user.id if current_user.is_authenticated else None,
-        download_cookie=user_cookie
+        user_id=current_user.id if current_user.is_authenticated else None, download_cookie=user_cookie
     ).first()
 
     if not existing_record:
@@ -728,7 +696,7 @@ def subdomain_index(doi):
     new_doi = doi_mapping_service.get_new_doi(doi)
     if new_doi:
         # Redirect to the same path with the new DOI
-        return redirect(url_for('dataset.subdomain_index', doi=new_doi), code=302)
+        return redirect(url_for("dataset.subdomain_index", doi=new_doi), code=302)
 
     # Try to search the dataset by the provided DOI (which should already be the new one)
     ds_meta_data = dsmetadata_service.filter_by_doi(doi)
@@ -760,36 +728,37 @@ def get_unsynchronized_dataset(dataset_id):
     return render_template("dataset/view_dataset.html", dataset=dataset)
 
 
-community_bp = Blueprint('community', __name__)
+community_bp = Blueprint("community", __name__)
 community_service = CommunityService()
 
 
-@community_bp.route('/communities', methods=['GET'])
+@community_bp.route("/communities", methods=["GET"])
 @login_required
 def list_communities():
     communities = CommunityService.list_communities()
     my_communities = CommunityService.get_communities_by_member(current_user)
-    return render_template('community/list_communities.html',
-                           my_communities=my_communities,
-                           communities=communities,
-                           current_user=current_user,
-                           is_owner=CommunityService.is_owner,
-                           is_member=CommunityService.is_member,
-                           is_request=CommunityService.is_request)
+    return render_template(
+        "community/list_communities.html",
+        my_communities=my_communities,
+        communities=communities,
+        current_user=current_user,
+        is_owner=CommunityService.is_owner,
+        is_member=CommunityService.is_member,
+        is_request=CommunityService.is_request,
+    )
 
 
-@community_bp.route('/communities/search', methods=['GET'])
+@community_bp.route("/communities/search", methods=["GET"])
 @login_required
 def search_communities():
-    query = request.args.get('query', '').strip()
+    query = request.args.get("query", "").strip()
     communities = CommunityService.search_communities(query)
-    return render_template('community/search_results.html',
-                           query=query,
-                           communities=communities,
-                           current_user=current_user)
+    return render_template(
+        "community/search_results.html", query=query, communities=communities, current_user=current_user
+    )
 
 
-@community_bp.route('/community/<int:community_id>', methods=['GET'])
+@community_bp.route("/community/<int:community_id>", methods=["GET"])
 @login_required
 def view_community(community_id):
     community = CommunityService.get_community_by_id(community_id)
@@ -803,37 +772,39 @@ def view_community(community_id):
 
     print(datasets[0].created_at)
 
-    return render_template('community/view_community.html',
-                           community=community,
-                           current_user=current_user,
-                           owners=owners,
-                           members=members,
-                           requests=requests,
-                           datasets=datasets,
-                           is_owner=CommunityService.is_owner,
-                           is_member=CommunityService.is_member,
-                           is_request=CommunityService.is_request)
+    return render_template(
+        "community/view_community.html",
+        community=community,
+        current_user=current_user,
+        owners=owners,
+        members=members,
+        requests=requests,
+        datasets=datasets,
+        is_owner=CommunityService.is_owner,
+        is_member=CommunityService.is_member,
+        is_request=CommunityService.is_request,
+    )
 
 
-@community_bp.route('/community/create', methods=['GET'])
+@community_bp.route("/community/create", methods=["GET"])
 @login_required
 def create_community_page():
-    return render_template('community/create_community.html')
+    return render_template("community/create_community.html")
 
 
-@community_bp.route('/community/create', methods=['POST'])
+@community_bp.route("/community/create", methods=["POST"])
 @login_required
 def create_community():
-    name = request.form.get('name')
+    name = request.form.get("name")
     if not name:
-        flash('Community name is required', 'danger')
-        return redirect(url_for('community.create_community_page'))
+        flash("Community name is required", "danger")
+        return redirect(url_for("community.create_community_page"))
     CommunityService.create_community(name, current_user)
-    flash('Community created successfully!', 'success')
-    return redirect(url_for('community.list_communities'))
+    flash("Community created successfully!", "success")
+    return redirect(url_for("community.list_communities"))
 
 
-@community_bp.route('/community/<int:community_id>/edit', methods=['GET'])
+@community_bp.route("/community/<int:community_id>/edit", methods=["GET"])
 @login_required
 def edit_community_page(community_id):
     community = CommunityService.get_community_by_id(community_id)
@@ -842,10 +813,10 @@ def edit_community_page(community_id):
     if not CommunityService.is_owner(community, current_user):
         return "Forbidden", 403
 
-    return render_template('community/edit_community.html', community=community)
+    return render_template("community/edit_community.html", community=community)
 
 
-@community_bp.route('/community/<int:community_id>/edit', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/edit", methods=["POST"])
 @login_required
 def edit_community(community_id):
     community = CommunityService.get_community_by_id(community_id)
@@ -853,13 +824,13 @@ def edit_community(community_id):
         return "Community not found", 404
     if not CommunityService.is_owner(community, current_user):
         return "Forbidden", 403
-    new_name = request.form.get('name')
+    new_name = request.form.get("name")
     updated_community = CommunityService.update_community(community_id, new_name)
 
-    return redirect(url_for('community.view_community', community_id=updated_community.id))
+    return redirect(url_for("community.view_community", community_id=updated_community.id))
 
 
-@community_bp.route('/community/<int:community_id>/delete', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/delete", methods=["POST"])
 @login_required
 def delete_community(community_id):
     community = CommunityService.get_community_by_id(community_id)
@@ -868,36 +839,36 @@ def delete_community(community_id):
     if not CommunityService.is_owner(community, current_user):
         return "Forbidden", 403
     CommunityService.remove_community(community_id)
-    return redirect(url_for('community.list_communities'))
+    return redirect(url_for("community.list_communities"))
 
 
-@community_bp.route('/community/<int:community_id>/request', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/request", methods=["POST"])
 @login_required
 def request_community(community_id):
     try:
         CommunityService.request_community(community_id, current_user)
-        flash('Request to join the community has been sent successfully.', 'success')
+        flash("Request to join the community has been sent successfully.", "success")
     except Exception as e:
-        flash(f'Error: {str(e)}', 'danger')
-    return redirect(url_for('community.view_community', community_id=community_id))
+        flash(f"Error: {str(e)}", "danger")
+    return redirect(url_for("community.view_community", community_id=community_id))
 
 
-@community_bp.route('/community/<int:community_id>/requests/<int:user_id>/<string:action>', methods=['POST'])
+@community_bp.route("/community/<int:community_id>/requests/<int:user_id>/<string:action>", methods=["POST"])
 @login_required
 def handle_request(community_id, user_id, action):
     community = CommunityService.get_community_by_id(community_id)
     if not community or not CommunityService.is_owner(community, current_user):
-        flash('You do not have permission to perform this action.', 'danger')
-        return redirect(url_for('community.view_community', community_id=community_id))
+        flash("You do not have permission to perform this action.", "danger")
+        return redirect(url_for("community.view_community", community_id=community_id))
 
     if action not in ["accept", "reject"]:
-        flash('Invalid action.', 'danger')
-        return redirect(url_for('community.view_community', community_id=community_id))
+        flash("Invalid action.", "danger")
+        return redirect(url_for("community.view_community", community_id=community_id))
 
     success = CommunityService.handle_request(community_id, user_id, action)
     if success:
-        flash('Request handled successfully.', 'success')
+        flash("Request handled successfully.", "success")
     else:
-        flash('Failed to handle the request.', 'danger')
+        flash("Failed to handle the request.", "danger")
 
-    return redirect(url_for('community.view_community', community_id=community_id))
+    return redirect(url_for("community.view_community", community_id=community_id))

--- a/app/modules/dataset/tests/test_selenium.py
+++ b/app/modules/dataset/tests/test_selenium.py
@@ -145,9 +145,7 @@ def test_upload_dataset_zip():
         driver.find_element(By.ID, "email").send_keys("user1@example.com")
         driver.find_element(By.ID, "password").send_keys("1234")
 
-        WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.ID, "submit"))
-        ).click()
+        WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.ID, "submit"))).click()
         wait_for_page_to_load(driver)
 
         # Navigate to "Upload from ZIP"
@@ -217,16 +215,14 @@ def test_download_all_dataset_logged_in():
     try:
 
         host = get_host_for_selenium_testing()
-                # Open the login page
+        # Open the login page
         driver.get(f"{host}/login")
         wait_for_page_to_load(driver)
 
         driver.find_element(By.ID, "email").send_keys("user1@example.com")
         driver.find_element(By.ID, "password").send_keys("1234")
 
-        WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.ID, "submit"))
-        ).click()
+        WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.ID, "submit"))).click()
         wait_for_page_to_load(driver)
 
         driver.get(f"{host}/")
@@ -243,6 +239,7 @@ def test_download_all_dataset_logged_in():
 
     finally:
         close_driver(driver)
+
 
 # Call the test functions
 test_upload_dataset()

--- a/app/modules/dataset/tests/test_selenium.py
+++ b/app/modules/dataset/tests/test_selenium.py
@@ -199,9 +199,7 @@ def test_upload_dataset_github():
         driver.find_element(By.ID, "email").send_keys("user1@example.com")
         driver.find_element(By.ID, "password").send_keys("1234")
 
-        WebDriverWait(driver, 10).until(
-            EC.element_to_be_clickable((By.ID, "submit"))
-        ).click()
+        WebDriverWait(driver, 10).until(EC.element_to_be_clickable((By.ID, "submit"))).click()
         wait_for_page_to_load(driver)
 
         driver.get(f"{host}/dataset/upload/github")

--- a/app/modules/dataset/tests/test_selenium.py
+++ b/app/modules/dataset/tests/test_selenium.py
@@ -239,7 +239,6 @@ def test_download_all_dataset_logged_in():
 
     finally:
         close_driver(driver)
-        
 
 
 # Call the test functions

--- a/app/modules/dataset/tests/test_selenium.py
+++ b/app/modules/dataset/tests/test_selenium.py
@@ -200,6 +200,8 @@ def test_download_all_dataset():
 
         # Navigate to "Download All"
         driver.get(f"{host}/dataset/download/all")
+        time.sleep(2)
+
         wait_for_page_to_load(driver)
         wait_for_page_to_load(driver)
 
@@ -209,9 +211,43 @@ def test_download_all_dataset():
         close_driver(driver)
 
 
+def test_download_all_dataset_logged_in():
+    driver = initialize_driver()
+
+    try:
+
+        host = get_host_for_selenium_testing()
+                # Open the login page
+        driver.get(f"{host}/login")
+        wait_for_page_to_load(driver)
+
+        driver.find_element(By.ID, "email").send_keys("user1@example.com")
+        driver.find_element(By.ID, "password").send_keys("1234")
+
+        WebDriverWait(driver, 10).until(
+            EC.element_to_be_clickable((By.ID, "submit"))
+        ).click()
+        wait_for_page_to_load(driver)
+
+        driver.get(f"{host}/")
+        time.sleep(2)
+
+        # Navigate to "Download All"
+        driver.get(f"{host}/dataset/download/all")
+        time.sleep(2)
+
+        wait_for_page_to_load(driver)
+        wait_for_page_to_load(driver)
+
+        print("Test passed!")
+
+    finally:
+        close_driver(driver)
+
 # Call the test functions
 test_upload_dataset()
 
 test_download_all_dataset()
+test_download_all_dataset_logged_in()
 
 test_upload_dataset_zip()

--- a/app/modules/dataset/tests/test_selenium.py
+++ b/app/modules/dataset/tests/test_selenium.py
@@ -239,6 +239,7 @@ def test_download_all_dataset_logged_in():
 
     finally:
         close_driver(driver)
+        
 
 
 # Call the test functions

--- a/app/modules/dataset/tests/test_unit.py
+++ b/app/modules/dataset/tests/test_unit.py
@@ -7,7 +7,6 @@ from io import BytesIO
 from zipfile import ZipFile
 from unittest.mock import patch
 from app import create_app, db
-from app.modules import hubfile
 from app.modules.auth.models import User
 from app.modules.dataset.forms import DataSetForm
 from app.modules.dataset.models import Author, DSMetaData, DSMetrics, DataSet, PublicationType

--- a/app/modules/dataset/tests/test_unit.py
+++ b/app/modules/dataset/tests/test_unit.py
@@ -1,15 +1,23 @@
+from datetime import datetime
+import os
+import tempfile
+from unittest import mock
 import pytest
 from io import BytesIO
 from zipfile import ZipFile
 from unittest.mock import patch
-
+from app import create_app, db
+from app.modules import hubfile
 from app.modules.auth.models import User
 from app.modules.dataset.forms import DataSetForm
-from app.modules.dataset.models import Author, DSMetaData, DSMetrics, DataSet
+from app.modules.dataset.models import Author, DSMetaData, DSMetrics, DataSet, PublicationType
 from app.modules.dataset.services import DataSetService
 from app.modules.featuremodel.models import FMMetaData, FeatureModel
 from app.modules.hubfile.models import Hubfile
 from app.modules.profile.models import UserProfile
+from flamapy.metamodels.fm_metamodel.transformations import UVLReader, GlencoeWriter, SPLOTWriter
+from flamapy.metamodels.pysat_metamodel.transformations import FmToPysat, DimacsWriter
+
 
 
 @pytest.fixture(scope="module")
@@ -23,6 +31,498 @@ def test_client(test_client):
         pass
 
     yield test_client
+
+
+# Fixture de pytest
+@pytest.fixture(scope="function")
+def client():
+    app = create_app('testing')  # Usamos el entorno de testing
+    with app.test_client() as client:
+        with app.app_context():
+            # Configuración de la base de datos en modo de prueba
+            db.drop_all()
+            db.create_all()
+
+            # Crear un usuario de prueba (user_33)
+            user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
+            db.session.add(user)
+            db.session.commit()
+
+            # Crear metadata para el dataset (dataset_33)
+            dsmetadata = DSMetaData(id=33, title="Sample Dataset 33", description="Description for dataset 33",
+                                    publication_type=PublicationType.DATA_MANAGEMENT_PLAN.name)
+            db.session.add(dsmetadata)
+            db.session.commit()
+
+            # Crear el dataset (dataset_33)
+            dataset = DataSet(id=33, user_id=user.id, ds_meta_data_id=dsmetadata.id)
+            db.session.add(dataset)
+            db.session.commit()
+
+            # Crear un feature_model y asociarlo al dataset
+            feature_model = FeatureModel(id=1, data_set_id=dataset.id)
+            db.session.add(feature_model)
+            db.session.commit()
+
+            # Crear un archivo Hubfile asociado al feature_model (sin 'path')
+            hubfile = Hubfile(id=1, feature_model_id=feature_model.id, name="file33.uvl",
+                              checksum="dummy_checksum", size=1234)
+            db.session.add(hubfile)
+            db.session.commit()
+
+            yield client
+
+            db.session.remove()
+            db.drop_all()
+
+
+# Test para la descarga de todos los datasets (esperando un archivo ZIP)
+def test_download_all_dataset(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        # Mockear al usuario correcto (user_33)
+        mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Crear datasets mock (dataset_33)
+        mock_datasets = [
+            mock.Mock(id=33, user_id=33, files=lambda: [mock.Mock(name="file33.uvl", id=1)]),
+        ]
+
+        # Mock de Hubfile con un id y un path
+        hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
+
+        # Mockear la llamada a HubfileService.get_or_404
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                # Aquí guardamos el archivo en la ruta esperada por la aplicación
+                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+                # Crear un archivo UVL válido para que Flamapy pueda procesarlo
+                with open(file_path, 'w') as f:
+                    f.write('features\n')
+                    f.write('    Chat\n')
+                    f.write('        mandatory\n')
+                    f.write('            Connection\n')
+                    f.write('                alternative\n')
+                    f.write('                    "Peer 2 Peer"\n')
+                    f.write('                    Server\n')
+                    f.write('            Messages\n')
+                    f.write('                or\n')
+                    f.write('                    Text\n')
+                    f.write('                    Video\n')
+                    f.write('                    Audio\n')
+                    f.write('        optional\n')
+                    f.write('            "Data Storage"\n')
+                    f.write('            "Media Player"\n')
+                    f.write('\n')
+                    f.write('constraints\n')
+                    f.write('    Server => "Data Storage"\n')
+                    f.write('    Video | Audio => "Media Player"\n')
+
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # Aquí comenzamos a crear el archivo ZIP
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        for file in dataset.files():
+                            # Hacer que file.name sea un string
+                            file.name = "file33.uvl"  # No es un Mock, es un string
+                            zipf.write(file_path, os.path.basename(file_path))
+                try:
+                    # Verificación de la existencia del archivo
+                    print(f"ZIP file exists at: {zip_path}")
+                    assert os.path.exists(zip_path)
+                    assert os.path.getsize(zip_path) > 0
+
+                    # Aquí va tu lógica de comprobación del contenido del ZIP
+                    with ZipFile(zip_path, 'r') as zipf:
+                        # Verifica el contenido
+                        zipf.testzip()  # Esto puede levantar una excepción si el ZIP está dañado
+
+                    response = client.get('/dataset/download/all')
+                    assert response.status_code == 200
+
+                finally:
+                    # Eliminar el archivo ZIP al final del test
+                    if os.path.exists(zip_path):
+                        os.remove(zip_path)
+                        print(f"Deleted ZIP file at: {zip_path}")
+
+
+# Test para la descarga de todos los datasets
+def test_download_all_dataset_splx(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        # Mockear al usuario correcto (user_33)
+        mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Crear datasets mock (dataset_33)
+        mock_datasets = [
+            mock.Mock(id=33, user_id=33, files=lambda: [mock.Mock(name="file33.uvl", id=1)]),
+        ]
+
+        # Mock de Hubfile con un id y un path
+        hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
+
+        # Mockear la llamada a HubfileService.get_or_404
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                # Aquí guardamos el archivo en la ruta esperada por la aplicación
+                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+                # Crear un archivo UVL válido para que Flamapy pueda procesarlo
+                with open(file_path, 'w') as f:
+                    f.write('features\n')
+                    f.write('    Chat\n')
+                    f.write('        mandatory\n')
+                    f.write('            Connection\n')
+                    f.write('                alternative\n')
+                    f.write('                    "Peer 2 Peer"\n')
+                    f.write('                    Server\n')
+                    f.write('            Messages\n')
+                    f.write('                or\n')
+                    f.write('                    Text\n')
+                    f.write('                    Video\n')
+                    f.write('                    Audio\n')
+                    f.write('        optional\n')
+                    f.write('            "Data Storage"\n')
+                    f.write('            "Media Player"\n')
+                    f.write('\n')
+                    f.write('constraints\n')
+                    f.write('    Server => "Data Storage"\n')
+                    f.write('    Video | Audio => "Media Player"\n')
+
+                # Crear el archivo ZIP de salida
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # Crear un archivo ZIP para simular la descarga
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        dataset_folder = f"dataset_{dataset.id}/"
+
+                        for file in dataset.files():
+                            content = ""
+                            # Convertir el archivo UVL a SPLX directamente aquí
+                            temp_file = tempfile.NamedTemporaryFile(suffix='.splx', delete=False)
+                            fm = UVLReader(hubfile_mock.get_path()).transform()
+                            SPLOTWriter(temp_file.name, fm).transform()
+                            with open(temp_file.name, "r") as new_format_file:
+                                content = new_format_file.read()
+
+                            # Nombre del archivo SPLX dentro del ZIP
+                            file_name_in_zip = f"{hubfile_mock.id}_splot.txt"
+                            
+                            # Agregar el archivo SPLX al archivo ZIP
+                            zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
+
+                            # Eliminar el archivo SPLX temporal después de agregarlo al ZIP
+                            os.remove(temp_file.name)
+
+                try:
+                    # Verificación de la existencia del archivo ZIP
+                    print(f"ZIP file exists at: {zip_path}")
+                    assert os.path.exists(zip_path)
+                    assert os.path.getsize(zip_path) > 0
+
+                    # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_splot.txt'
+                    with ZipFile(zip_path, 'r') as zipf:
+                        # Obtener los nombres de los archivos dentro del ZIP
+                        zip_file_names = zipf.namelist()
+                        
+                        # Verificar que al menos un archivo tenga el sufijo '_splot.txt'
+                        assert any(name.endswith('_splot.txt') for name in zip_file_names)
+                    # Simulamos una llamada a la descarga del archivo ZIP
+                    response = client.get('/dataset/download/all')
+                    assert response.status_code == 200
+
+                finally:
+                    # Eliminar el archivo ZIP al final del test
+                    if os.path.exists(zip_path):
+                        os.remove(zip_path)
+                        print(f"Deleted ZIP file at: {zip_path}")
+
+# Test para la descarga de todos los datasets
+def test_download_all_dataset_glencoe(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        # Mockear al usuario correcto (user_33)
+        mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Crear datasets mock (dataset_33)
+        mock_datasets = [
+            mock.Mock(id=33, user_id=33, files=lambda: [mock.Mock(name="file33.uvl", id=1)]),
+        ]
+
+        # Mock de Hubfile con un id y un path
+        hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
+
+        # Mockear la llamada a HubfileService.get_or_404
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                # Aquí guardamos el archivo en la ruta esperada por la aplicación
+                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+                # Crear un archivo UVL válido para que Flamapy pueda procesarlo
+                with open(file_path, 'w') as f:
+                    f.write('features\n')
+                    f.write('    Chat\n')
+                    f.write('        mandatory\n')
+                    f.write('            Connection\n')
+                    f.write('                alternative\n')
+                    f.write('                    "Peer 2 Peer"\n')
+                    f.write('                    Server\n')
+                    f.write('            Messages\n')
+                    f.write('                or\n')
+                    f.write('                    Text\n')
+                    f.write('                    Video\n')
+                    f.write('                    Audio\n')
+                    f.write('        optional\n')
+                    f.write('            "Data Storage"\n')
+                    f.write('            "Media Player"\n')
+                    f.write('\n')
+                    f.write('constraints\n')
+                    f.write('    Server => "Data Storage"\n')
+                    f.write('    Video | Audio => "Media Player"\n')
+
+                # Crear el archivo ZIP de salida
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # Crear un archivo ZIP para simular la descarga
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        dataset_folder = f"dataset_{dataset.id}/"
+
+                        for file in dataset.files():
+                            content = ""
+                            temp_file = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+                            fm = UVLReader(hubfile_mock.get_path()).transform()
+                            GlencoeWriter(temp_file.name, fm).transform()
+                            with open(temp_file.name, "r") as new_format_file:
+                                content = new_format_file.read()
+
+                            # Nombre del archivo dentro del ZIP
+                            file_name_in_zip = f"{hubfile_mock.id}_glencoe.txt"
+                            
+                            # Agregar el archivo al archivo ZIP
+                            zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
+
+                            # Eliminar el archivo temporal después de agregarlo al ZIP
+                            os.remove(temp_file.name)
+
+                try:
+                    # Verificación de la existencia del archivo ZIP
+                    print(f"ZIP file exists at: {zip_path}")
+                    assert os.path.exists(zip_path)
+                    assert os.path.getsize(zip_path) > 0
+
+                    # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_glencoe.txt'
+                    with ZipFile(zip_path, 'r') as zipf:
+                        # Obtener los nombres de los archivos dentro del ZIP
+                        zip_file_names = zipf.namelist()
+                        
+                        # Verificar que al menos un archivo tenga el sufijo '_glencoe.txt'
+                        assert any(name.endswith('_glencoe.txt') for name in zip_file_names)
+                    # Simulamos una llamada a la descarga del archivo ZIP
+                    response = client.get('/dataset/download/all')
+                    assert response.status_code == 200
+
+                finally:
+                    # Eliminar el archivo ZIP al final del test
+                    if os.path.exists(zip_path):
+                        os.remove(zip_path)
+                        print(f"Deleted ZIP file at: {zip_path}")
+
+
+# Test para la descarga de todos los datasets
+def test_download_all_dataset_dimacs(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        # Mockear al usuario correcto (user_33)
+        mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Crear datasets mock (dataset_33)
+        mock_datasets = [
+            mock.Mock(id=33, user_id=33, files=lambda: [mock.Mock(name="file33.uvl", id=1)]),
+        ]
+
+        # Mock de Hubfile con un id y un path
+        hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
+
+        # Mockear la llamada a HubfileService.get_or_404
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                # Aquí guardamos el archivo en la ruta esperada por la aplicación
+                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+                # Crear un archivo UVL válido para que Flamapy pueda procesarlo
+                with open(file_path, 'w') as f:
+                    f.write('features\n')
+                    f.write('    Chat\n')
+                    f.write('        mandatory\n')
+                    f.write('            Connection\n')
+                    f.write('                alternative\n')
+                    f.write('                    "Peer 2 Peer"\n')
+                    f.write('                    Server\n')
+                    f.write('            Messages\n')
+                    f.write('                or\n')
+                    f.write('                    Text\n')
+                    f.write('                    Video\n')
+                    f.write('                    Audio\n')
+                    f.write('        optional\n')
+                    f.write('            "Data Storage"\n')
+                    f.write('            "Media Player"\n')
+                    f.write('\n')
+                    f.write('constraints\n')
+                    f.write('    Server => "Data Storage"\n')
+                    f.write('    Video | Audio => "Media Player"\n')
+
+                # Crear el archivo ZIP de salida
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # Crear un archivo ZIP para simular la descarga
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        dataset_folder = f"dataset_{dataset.id}/"
+
+                        for file in dataset.files():
+                            content = ""
+                            temp_file = tempfile.NamedTemporaryFile(suffix='.cnf', delete=False)
+                            fm = UVLReader(hubfile_mock.get_path()).transform()
+                            sat = FmToPysat(fm).transform()
+                            DimacsWriter(temp_file.name, sat).transform()
+                            with open(temp_file.name, "r") as new_format_file:
+                                content = new_format_file.read()
+
+                            # Nombre del archivo dentro del ZIP
+                            file_name_in_zip = f"{hubfile_mock.id}_cnf.txt"
+                            
+                            # Agregar el archivo al archivo ZIP
+                            zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
+
+                            # Eliminar el archivo temporal después de agregarlo al ZIP
+                            os.remove(temp_file.name)
+
+                try:
+                    # Verificación de la existencia del archivo ZIP
+                    print(f"ZIP file exists at: {zip_path}")
+                    assert os.path.exists(zip_path)
+                    assert os.path.getsize(zip_path) > 0
+
+                    # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_cnf.txt'
+                    with ZipFile(zip_path, 'r') as zipf:
+                        # Obtener los nombres de los archivos dentro del ZIP
+                        zip_file_names = zipf.namelist()
+                        
+                        # Verificar que al menos un archivo tenga el sufijo '_cnf.txt'
+                        assert any(name.endswith('_cnf.txt') for name in zip_file_names)
+                    # Simulamos una llamada a la descarga del archivo ZIP
+                    response = client.get('/dataset/download/all')
+                    assert response.status_code == 200
+
+                finally:
+                    # Eliminar el archivo ZIP al final del test
+                    if os.path.exists(zip_path):
+                        os.remove(zip_path)
+                        print(f"Deleted ZIP file at: {zip_path}")
+
+# Test para la descarga de todos los datasets (cuando los archivos no se encuentran)
+def test_download_all_dataset_files_not_found(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        mock_user = User(id=5, email="user5@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Configuramos el mock para `files()` que devuelve una lista vacía
+        mock_datasets = [
+            mock.Mock(id=20, user_id=5, files=lambda: [mock.Mock(name="fileX.uvl", id=1)]),
+        ]
+
+        # Simulamos un escenario donde el archivo no está presente
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', side_effect=FileNotFoundError):
+            # No deberíamos poder crear archivos si no hay archivos disponibles
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # No deberíamos poder crear archivos si no hay archivos disponibles
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        for file in dataset.files():
+                            try:
+                                file.name = str(file.name)
+                                file_path = os.path.join(tmpdirname, file.name)
+                                with open(file_path, 'w') as f:
+                                    f.write('Contenido simulado de archivo')
+                                zipf.write(file_path, os.path.basename(file_path))
+                            except FileNotFoundError:
+                                pass
+            try:
+                # Llamamos a la ruta para descargar todos los datasets
+                response = client.get('/dataset/download/all')
+
+                # Verificamos que el status de la respuesta es 404 (No encontrado)
+                assert response.status_code == 404
+
+                # Verificar que la respuesta sea un JSON
+                assert response.content_type == 'application/json'
+
+                # Verificar el contenido del JSON (mensaje de error esperado)
+                json_response = response.get_json()
+                assert 'error' in json_response
+                assert json_response['error'] == 'No se encontraron archivos disponibles para descargar'
+            finally:
+                if os.path.exists(zip_path):
+                    os.remove(zip_path)
+
+
+# Test para la descarga de todos los datasets (cuando los archivos no se encuentran)
+def test_download_all_dataset_empty(client):
+    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+        mock_user = User(id=5, email="user5@example.com", password="1234", created_at=datetime(2022, 3, 13))
+        mock_get_user.return_value = mock_user
+
+        # Configuramos el mock para `files()` que devuelve una lista vacía
+        mock_datasets = [
+            mock.Mock(id=20, user_id=5, files=lambda: []),
+        ]
+
+        # Simulamos un escenario donde el archivo no está presente
+        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', side_effect=FileNotFoundError):
+            # No deberíamos poder crear archivos si no hay archivos disponibles
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+
+                # No deberíamos poder crear archivos si no hay archivos disponibles
+                with ZipFile(zip_path, "w") as zipf:
+                    for dataset in mock_datasets:
+                        for file in dataset.files():
+                            try:
+                                file.name = str(file.name)
+                                file_path = os.path.join(tmpdirname, file.name)
+                                with open(file_path, 'w') as f:
+                                    f.write('Contenido simulado de archivo')
+                                zipf.write(file_path, os.path.basename(file_path))
+                            except FileNotFoundError:
+                                pass
+            try:
+                # Llamamos a la ruta para descargar todos los datasets
+                response = client.get('/dataset/download/all')
+
+                # Verificamos que el status de la respuesta es 404 (No encontrado)
+                assert response.status_code == 404
+
+                # Verificar que la respuesta sea un JSON
+                assert response.content_type == 'application/json'
+
+                # Verificar el contenido del JSON (mensaje de error esperado)
+                json_response = response.get_json()
+                assert 'error' in json_response
+                assert json_response['error'] == 'No se encontraron archivos disponibles para descargar'
+            finally:
+                if os.path.exists(zip_path):
+                    os.remove(zip_path)
 
 
 @pytest.fixture

--- a/app/modules/dataset/tests/test_unit.py
+++ b/app/modules/dataset/tests/test_unit.py
@@ -19,7 +19,6 @@ from flamapy.metamodels.fm_metamodel.transformations import UVLReader, GlencoeWr
 from flamapy.metamodels.pysat_metamodel.transformations import FmToPysat, DimacsWriter
 
 
-
 @pytest.fixture(scope="module")
 def test_client(test_client):
     """
@@ -36,7 +35,7 @@ def test_client(test_client):
 # Fixture de pytest
 @pytest.fixture(scope="function")
 def client():
-    app = create_app('testing')  # Usamos el entorno de testing
+    app = create_app("testing")  # Usamos el entorno de testing
     with app.test_client() as client:
         with app.app_context():
             # Configuración de la base de datos en modo de prueba
@@ -49,8 +48,12 @@ def client():
             db.session.commit()
 
             # Crear metadata para el dataset (dataset_33)
-            dsmetadata = DSMetaData(id=33, title="Sample Dataset 33", description="Description for dataset 33",
-                                    publication_type=PublicationType.DATA_MANAGEMENT_PLAN.name)
+            dsmetadata = DSMetaData(
+                id=33,
+                title="Sample Dataset 33",
+                description="Description for dataset 33",
+                publication_type=PublicationType.DATA_MANAGEMENT_PLAN.name,
+            )
             db.session.add(dsmetadata)
             db.session.commit()
 
@@ -65,8 +68,9 @@ def client():
             db.session.commit()
 
             # Crear un archivo Hubfile asociado al feature_model (sin 'path')
-            hubfile = Hubfile(id=1, feature_model_id=feature_model.id, name="file33.uvl",
-                              checksum="dummy_checksum", size=1234)
+            hubfile = Hubfile(
+                id=1, feature_model_id=feature_model.id, name="file33.uvl", checksum="dummy_checksum", size=1234
+            )
             db.session.add(hubfile)
             db.session.commit()
 
@@ -78,7 +82,7 @@ def client():
 
 # Test para la descarga de todos los datasets (esperando un archivo ZIP)
 def test_download_all_dataset(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         # Mockear al usuario correcto (user_33)
         mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
@@ -92,35 +96,35 @@ def test_download_all_dataset(client):
         hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
 
         # Mockear la llamada a HubfileService.get_or_404
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", return_value=hubfile_mock):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 # Aquí guardamos el archivo en la ruta esperada por la aplicación
-                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                file_path = os.path.join("uploads/", f"user_{mock_user.id}", f"dataset_{33}", "file33.uvl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
                 # Crear un archivo UVL válido para que Flamapy pueda procesarlo
-                with open(file_path, 'w') as f:
-                    f.write('features\n')
-                    f.write('    Chat\n')
-                    f.write('        mandatory\n')
-                    f.write('            Connection\n')
-                    f.write('                alternative\n')
+                with open(file_path, "w") as f:
+                    f.write("features\n")
+                    f.write("    Chat\n")
+                    f.write("        mandatory\n")
+                    f.write("            Connection\n")
+                    f.write("                alternative\n")
                     f.write('                    "Peer 2 Peer"\n')
-                    f.write('                    Server\n')
-                    f.write('            Messages\n')
-                    f.write('                or\n')
-                    f.write('                    Text\n')
-                    f.write('                    Video\n')
-                    f.write('                    Audio\n')
-                    f.write('        optional\n')
+                    f.write("                    Server\n")
+                    f.write("            Messages\n")
+                    f.write("                or\n")
+                    f.write("                    Text\n")
+                    f.write("                    Video\n")
+                    f.write("                    Audio\n")
+                    f.write("        optional\n")
                     f.write('            "Data Storage"\n')
                     f.write('            "Media Player"\n')
-                    f.write('\n')
-                    f.write('constraints\n')
+                    f.write("\n")
+                    f.write("constraints\n")
                     f.write('    Server => "Data Storage"\n')
                     f.write('    Video | Audio => "Media Player"\n')
 
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # Aquí comenzamos a crear el archivo ZIP
                 with ZipFile(zip_path, "w") as zipf:
@@ -136,11 +140,11 @@ def test_download_all_dataset(client):
                     assert os.path.getsize(zip_path) > 0
 
                     # Aquí va tu lógica de comprobación del contenido del ZIP
-                    with ZipFile(zip_path, 'r') as zipf:
+                    with ZipFile(zip_path, "r") as zipf:
                         # Verifica el contenido
                         zipf.testzip()  # Esto puede levantar una excepción si el ZIP está dañado
 
-                    response = client.get('/dataset/download/all')
+                    response = client.get("/dataset/download/all")
                     assert response.status_code == 200
 
                 finally:
@@ -152,7 +156,7 @@ def test_download_all_dataset(client):
 
 # Test para la descarga de todos los datasets
 def test_download_all_dataset_splx(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         # Mockear al usuario correcto (user_33)
         mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
@@ -166,36 +170,36 @@ def test_download_all_dataset_splx(client):
         hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
 
         # Mockear la llamada a HubfileService.get_or_404
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", return_value=hubfile_mock):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 # Aquí guardamos el archivo en la ruta esperada por la aplicación
-                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                file_path = os.path.join("uploads/", f"user_{mock_user.id}", f"dataset_{33}", "file33.uvl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
                 # Crear un archivo UVL válido para que Flamapy pueda procesarlo
-                with open(file_path, 'w') as f:
-                    f.write('features\n')
-                    f.write('    Chat\n')
-                    f.write('        mandatory\n')
-                    f.write('            Connection\n')
-                    f.write('                alternative\n')
+                with open(file_path, "w") as f:
+                    f.write("features\n")
+                    f.write("    Chat\n")
+                    f.write("        mandatory\n")
+                    f.write("            Connection\n")
+                    f.write("                alternative\n")
                     f.write('                    "Peer 2 Peer"\n')
-                    f.write('                    Server\n')
-                    f.write('            Messages\n')
-                    f.write('                or\n')
-                    f.write('                    Text\n')
-                    f.write('                    Video\n')
-                    f.write('                    Audio\n')
-                    f.write('        optional\n')
+                    f.write("                    Server\n")
+                    f.write("            Messages\n")
+                    f.write("                or\n")
+                    f.write("                    Text\n")
+                    f.write("                    Video\n")
+                    f.write("                    Audio\n")
+                    f.write("        optional\n")
                     f.write('            "Data Storage"\n')
                     f.write('            "Media Player"\n')
-                    f.write('\n')
-                    f.write('constraints\n')
+                    f.write("\n")
+                    f.write("constraints\n")
                     f.write('    Server => "Data Storage"\n')
                     f.write('    Video | Audio => "Media Player"\n')
 
                 # Crear el archivo ZIP de salida
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # Crear un archivo ZIP para simular la descarga
                 with ZipFile(zip_path, "w") as zipf:
@@ -205,7 +209,7 @@ def test_download_all_dataset_splx(client):
                         for file in dataset.files():
                             content = ""
                             # Convertir el archivo UVL a SPLX directamente aquí
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.splx', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".splx", delete=False)
                             fm = UVLReader(hubfile_mock.get_path()).transform()
                             SPLOTWriter(temp_file.name, fm).transform()
                             with open(temp_file.name, "r") as new_format_file:
@@ -213,7 +217,7 @@ def test_download_all_dataset_splx(client):
 
                             # Nombre del archivo SPLX dentro del ZIP
                             file_name_in_zip = f"{hubfile_mock.id}_splot.txt"
-                            
+
                             # Agregar el archivo SPLX al archivo ZIP
                             zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
 
@@ -227,14 +231,14 @@ def test_download_all_dataset_splx(client):
                     assert os.path.getsize(zip_path) > 0
 
                     # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_splot.txt'
-                    with ZipFile(zip_path, 'r') as zipf:
+                    with ZipFile(zip_path, "r") as zipf:
                         # Obtener los nombres de los archivos dentro del ZIP
                         zip_file_names = zipf.namelist()
-                        
+
                         # Verificar que al menos un archivo tenga el sufijo '_splot.txt'
-                        assert any(name.endswith('_splot.txt') for name in zip_file_names)
+                        assert any(name.endswith("_splot.txt") for name in zip_file_names)
                     # Simulamos una llamada a la descarga del archivo ZIP
-                    response = client.get('/dataset/download/all')
+                    response = client.get("/dataset/download/all")
                     assert response.status_code == 200
 
                 finally:
@@ -243,9 +247,10 @@ def test_download_all_dataset_splx(client):
                         os.remove(zip_path)
                         print(f"Deleted ZIP file at: {zip_path}")
 
+
 # Test para la descarga de todos los datasets
 def test_download_all_dataset_glencoe(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         # Mockear al usuario correcto (user_33)
         mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
@@ -259,36 +264,36 @@ def test_download_all_dataset_glencoe(client):
         hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
 
         # Mockear la llamada a HubfileService.get_or_404
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", return_value=hubfile_mock):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 # Aquí guardamos el archivo en la ruta esperada por la aplicación
-                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                file_path = os.path.join("uploads/", f"user_{mock_user.id}", f"dataset_{33}", "file33.uvl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
                 # Crear un archivo UVL válido para que Flamapy pueda procesarlo
-                with open(file_path, 'w') as f:
-                    f.write('features\n')
-                    f.write('    Chat\n')
-                    f.write('        mandatory\n')
-                    f.write('            Connection\n')
-                    f.write('                alternative\n')
+                with open(file_path, "w") as f:
+                    f.write("features\n")
+                    f.write("    Chat\n")
+                    f.write("        mandatory\n")
+                    f.write("            Connection\n")
+                    f.write("                alternative\n")
                     f.write('                    "Peer 2 Peer"\n')
-                    f.write('                    Server\n')
-                    f.write('            Messages\n')
-                    f.write('                or\n')
-                    f.write('                    Text\n')
-                    f.write('                    Video\n')
-                    f.write('                    Audio\n')
-                    f.write('        optional\n')
+                    f.write("                    Server\n")
+                    f.write("            Messages\n")
+                    f.write("                or\n")
+                    f.write("                    Text\n")
+                    f.write("                    Video\n")
+                    f.write("                    Audio\n")
+                    f.write("        optional\n")
                     f.write('            "Data Storage"\n')
                     f.write('            "Media Player"\n')
-                    f.write('\n')
-                    f.write('constraints\n')
+                    f.write("\n")
+                    f.write("constraints\n")
                     f.write('    Server => "Data Storage"\n')
                     f.write('    Video | Audio => "Media Player"\n')
 
                 # Crear el archivo ZIP de salida
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # Crear un archivo ZIP para simular la descarga
                 with ZipFile(zip_path, "w") as zipf:
@@ -297,7 +302,7 @@ def test_download_all_dataset_glencoe(client):
 
                         for file in dataset.files():
                             content = ""
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.json', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".json", delete=False)
                             fm = UVLReader(hubfile_mock.get_path()).transform()
                             GlencoeWriter(temp_file.name, fm).transform()
                             with open(temp_file.name, "r") as new_format_file:
@@ -305,7 +310,7 @@ def test_download_all_dataset_glencoe(client):
 
                             # Nombre del archivo dentro del ZIP
                             file_name_in_zip = f"{hubfile_mock.id}_glencoe.txt"
-                            
+
                             # Agregar el archivo al archivo ZIP
                             zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
 
@@ -319,14 +324,14 @@ def test_download_all_dataset_glencoe(client):
                     assert os.path.getsize(zip_path) > 0
 
                     # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_glencoe.txt'
-                    with ZipFile(zip_path, 'r') as zipf:
+                    with ZipFile(zip_path, "r") as zipf:
                         # Obtener los nombres de los archivos dentro del ZIP
                         zip_file_names = zipf.namelist()
-                        
+
                         # Verificar que al menos un archivo tenga el sufijo '_glencoe.txt'
-                        assert any(name.endswith('_glencoe.txt') for name in zip_file_names)
+                        assert any(name.endswith("_glencoe.txt") for name in zip_file_names)
                     # Simulamos una llamada a la descarga del archivo ZIP
-                    response = client.get('/dataset/download/all')
+                    response = client.get("/dataset/download/all")
                     assert response.status_code == 200
 
                 finally:
@@ -338,7 +343,7 @@ def test_download_all_dataset_glencoe(client):
 
 # Test para la descarga de todos los datasets
 def test_download_all_dataset_dimacs(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         # Mockear al usuario correcto (user_33)
         mock_user = User(id=33, email="user33@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
@@ -352,36 +357,36 @@ def test_download_all_dataset_dimacs(client):
         hubfile_mock = mock.Mock(id=1, get_path=lambda: f"uploads/user_{mock_user.id}/dataset_{33}/file33.uvl")
 
         # Mockear la llamada a HubfileService.get_or_404
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', return_value=hubfile_mock):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", return_value=hubfile_mock):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 # Aquí guardamos el archivo en la ruta esperada por la aplicación
-                file_path = os.path.join("uploads/", f'user_{mock_user.id}', f'dataset_{33}', 'file33.uvl')
+                file_path = os.path.join("uploads/", f"user_{mock_user.id}", f"dataset_{33}", "file33.uvl")
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
                 # Crear un archivo UVL válido para que Flamapy pueda procesarlo
-                with open(file_path, 'w') as f:
-                    f.write('features\n')
-                    f.write('    Chat\n')
-                    f.write('        mandatory\n')
-                    f.write('            Connection\n')
-                    f.write('                alternative\n')
+                with open(file_path, "w") as f:
+                    f.write("features\n")
+                    f.write("    Chat\n")
+                    f.write("        mandatory\n")
+                    f.write("            Connection\n")
+                    f.write("                alternative\n")
                     f.write('                    "Peer 2 Peer"\n')
-                    f.write('                    Server\n')
-                    f.write('            Messages\n')
-                    f.write('                or\n')
-                    f.write('                    Text\n')
-                    f.write('                    Video\n')
-                    f.write('                    Audio\n')
-                    f.write('        optional\n')
+                    f.write("                    Server\n")
+                    f.write("            Messages\n")
+                    f.write("                or\n")
+                    f.write("                    Text\n")
+                    f.write("                    Video\n")
+                    f.write("                    Audio\n")
+                    f.write("        optional\n")
                     f.write('            "Data Storage"\n')
                     f.write('            "Media Player"\n')
-                    f.write('\n')
-                    f.write('constraints\n')
+                    f.write("\n")
+                    f.write("constraints\n")
                     f.write('    Server => "Data Storage"\n')
                     f.write('    Video | Audio => "Media Player"\n')
 
                 # Crear el archivo ZIP de salida
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # Crear un archivo ZIP para simular la descarga
                 with ZipFile(zip_path, "w") as zipf:
@@ -390,7 +395,7 @@ def test_download_all_dataset_dimacs(client):
 
                         for file in dataset.files():
                             content = ""
-                            temp_file = tempfile.NamedTemporaryFile(suffix='.cnf', delete=False)
+                            temp_file = tempfile.NamedTemporaryFile(suffix=".cnf", delete=False)
                             fm = UVLReader(hubfile_mock.get_path()).transform()
                             sat = FmToPysat(fm).transform()
                             DimacsWriter(temp_file.name, sat).transform()
@@ -399,7 +404,7 @@ def test_download_all_dataset_dimacs(client):
 
                             # Nombre del archivo dentro del ZIP
                             file_name_in_zip = f"{hubfile_mock.id}_cnf.txt"
-                            
+
                             # Agregar el archivo al archivo ZIP
                             zipf.writestr(os.path.join(dataset_folder, file_name_in_zip), content)
 
@@ -413,14 +418,14 @@ def test_download_all_dataset_dimacs(client):
                     assert os.path.getsize(zip_path) > 0
 
                     # Abrir el ZIP y comprobar que contiene el archivo con el sufijo '_cnf.txt'
-                    with ZipFile(zip_path, 'r') as zipf:
+                    with ZipFile(zip_path, "r") as zipf:
                         # Obtener los nombres de los archivos dentro del ZIP
                         zip_file_names = zipf.namelist()
-                        
+
                         # Verificar que al menos un archivo tenga el sufijo '_cnf.txt'
-                        assert any(name.endswith('_cnf.txt') for name in zip_file_names)
+                        assert any(name.endswith("_cnf.txt") for name in zip_file_names)
                     # Simulamos una llamada a la descarga del archivo ZIP
-                    response = client.get('/dataset/download/all')
+                    response = client.get("/dataset/download/all")
                     assert response.status_code == 200
 
                 finally:
@@ -429,9 +434,10 @@ def test_download_all_dataset_dimacs(client):
                         os.remove(zip_path)
                         print(f"Deleted ZIP file at: {zip_path}")
 
+
 # Test para la descarga de todos los datasets (cuando los archivos no se encuentran)
 def test_download_all_dataset_files_not_found(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         mock_user = User(id=5, email="user5@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
 
@@ -441,10 +447,10 @@ def test_download_all_dataset_files_not_found(client):
         ]
 
         # Simulamos un escenario donde el archivo no está presente
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', side_effect=FileNotFoundError):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", side_effect=FileNotFoundError):
             # No deberíamos poder crear archivos si no hay archivos disponibles
             with tempfile.TemporaryDirectory() as tmpdirname:
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # No deberíamos poder crear archivos si no hay archivos disponibles
                 with ZipFile(zip_path, "w") as zipf:
@@ -453,25 +459,25 @@ def test_download_all_dataset_files_not_found(client):
                             try:
                                 file.name = str(file.name)
                                 file_path = os.path.join(tmpdirname, file.name)
-                                with open(file_path, 'w') as f:
-                                    f.write('Contenido simulado de archivo')
+                                with open(file_path, "w") as f:
+                                    f.write("Contenido simulado de archivo")
                                 zipf.write(file_path, os.path.basename(file_path))
                             except FileNotFoundError:
                                 pass
             try:
                 # Llamamos a la ruta para descargar todos los datasets
-                response = client.get('/dataset/download/all')
+                response = client.get("/dataset/download/all")
 
                 # Verificamos que el status de la respuesta es 404 (No encontrado)
                 assert response.status_code == 404
 
                 # Verificar que la respuesta sea un JSON
-                assert response.content_type == 'application/json'
+                assert response.content_type == "application/json"
 
                 # Verificar el contenido del JSON (mensaje de error esperado)
                 json_response = response.get_json()
-                assert 'error' in json_response
-                assert json_response['error'] == 'No se encontraron archivos disponibles para descargar'
+                assert "error" in json_response
+                assert json_response["error"] == "No se encontraron archivos disponibles para descargar"
             finally:
                 if os.path.exists(zip_path):
                     os.remove(zip_path)
@@ -479,7 +485,7 @@ def test_download_all_dataset_files_not_found(client):
 
 # Test para la descarga de todos los datasets (cuando los archivos no se encuentran)
 def test_download_all_dataset_empty(client):
-    with mock.patch('flask_login.utils._get_user') as mock_get_user:
+    with mock.patch("flask_login.utils._get_user") as mock_get_user:
         mock_user = User(id=5, email="user5@example.com", password="1234", created_at=datetime(2022, 3, 13))
         mock_get_user.return_value = mock_user
 
@@ -489,10 +495,10 @@ def test_download_all_dataset_empty(client):
         ]
 
         # Simulamos un escenario donde el archivo no está presente
-        with mock.patch('app.modules.hubfile.services.HubfileService.get_or_404', side_effect=FileNotFoundError):
+        with mock.patch("app.modules.hubfile.services.HubfileService.get_or_404", side_effect=FileNotFoundError):
             # No deberíamos poder crear archivos si no hay archivos disponibles
             with tempfile.TemporaryDirectory() as tmpdirname:
-                zip_path = os.path.join(tmpdirname, 'all_datasets.zip')
+                zip_path = os.path.join(tmpdirname, "all_datasets.zip")
 
                 # No deberíamos poder crear archivos si no hay archivos disponibles
                 with ZipFile(zip_path, "w") as zipf:
@@ -501,25 +507,25 @@ def test_download_all_dataset_empty(client):
                             try:
                                 file.name = str(file.name)
                                 file_path = os.path.join(tmpdirname, file.name)
-                                with open(file_path, 'w') as f:
-                                    f.write('Contenido simulado de archivo')
+                                with open(file_path, "w") as f:
+                                    f.write("Contenido simulado de archivo")
                                 zipf.write(file_path, os.path.basename(file_path))
                             except FileNotFoundError:
                                 pass
             try:
                 # Llamamos a la ruta para descargar todos los datasets
-                response = client.get('/dataset/download/all')
+                response = client.get("/dataset/download/all")
 
                 # Verificamos que el status de la respuesta es 404 (No encontrado)
                 assert response.status_code == 404
 
                 # Verificar que la respuesta sea un JSON
-                assert response.content_type == 'application/json'
+                assert response.content_type == "application/json"
 
                 # Verificar el contenido del JSON (mensaje de error esperado)
                 json_response = response.get_json()
-                assert 'error' in json_response
-                assert json_response['error'] == 'No se encontraron archivos disponibles para descargar'
+                assert "error" in json_response
+                assert json_response["error"] == "No se encontraron archivos disponibles para descargar"
             finally:
                 if os.path.exists(zip_path):
                     os.remove(zip_path)
@@ -535,16 +541,16 @@ def login(test_client):
     )
     assert response.status_code == 200 and response.request.path == "/"
 
-    cookies = response.headers.getlist('Set-Cookie')
+    cookies = response.headers.getlist("Set-Cookie")
 
     remember_token = None
     session = None
 
     for cookie in cookies:
-        if 'remember_token' in cookie:
-            remember_token = cookie.split(';')[0].split('=')[1]
-        elif 'session' in cookie:
-            session = cookie.split(';')[0].split('=')[1]
+        if "remember_token" in cookie:
+            remember_token = cookie.split(";")[0].split("=")[1]
+        elif "session" in cookie:
+            session = cookie.split(";")[0].split("=")[1]
 
     return remember_token, session
 
@@ -556,20 +562,17 @@ def test_upload_valid_zip(test_client, login):
     remember_token, session = login
 
     zip_buffer = BytesIO()
-    with ZipFile(zip_buffer, 'w') as zip_file:
-        zip_file.writestr('testfile.uvl', 'contenido del archivo UVL')
+    with ZipFile(zip_buffer, "w") as zip_file:
+        zip_file.writestr("testfile.uvl", "contenido del archivo UVL")
 
     zip_buffer.seek(0)
-    data = {
-        'file': (zip_buffer, 'test.zip')
-    }
+    data = {"file": (zip_buffer, "test.zip")}
 
-    headers = {
-        'Cookie': f'remember_token={remember_token}; session={session}'
-    }
+    headers = {"Cookie": f"remember_token={remember_token}; session={session}"}
 
-    response = test_client.post('/dataset/file/upload/zip',
-                                data=data, headers=headers, content_type='multipart/form-data')
+    response = test_client.post(
+        "/dataset/file/upload/zip", data=data, headers=headers, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 200
 
@@ -581,18 +584,17 @@ def test_upload_zip_without_uvl(test_client, login):
     remember_token, session = login
 
     zip_buffer = BytesIO()
-    with ZipFile(zip_buffer, 'w') as zip_file:
-        zip_file.writestr('testfile.txt', 'contenido del archivo de texto')
+    with ZipFile(zip_buffer, "w") as zip_file:
+        zip_file.writestr("testfile.txt", "contenido del archivo de texto")
 
     zip_buffer.seek(0)
-    data = {
-        'file': (zip_buffer, 'test.zip')
-    }
+    data = {"file": (zip_buffer, "test.zip")}
 
-    headers = {'Cookie': f'remember_token={remember_token}; session={session}'}
+    headers = {"Cookie": f"remember_token={remember_token}; session={session}"}
 
-    response = test_client.post('/dataset/file/upload/zip',
-                                data=data, headers=headers, content_type='multipart/form-data')
+    response = test_client.post(
+        "/dataset/file/upload/zip", data=data, headers=headers, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 400
 
@@ -603,14 +605,13 @@ def test_upload_invalid_zip(test_client, login):
     """
     remember_token, session = login
 
-    data = {
-        'file': (BytesIO(b"Not a zip file"), 'invalid.zip')
-    }
+    data = {"file": (BytesIO(b"Not a zip file"), "invalid.zip")}
 
-    headers = {'Cookie': f'remember_token={remember_token}; session={session}'}
+    headers = {"Cookie": f"remember_token={remember_token}; session={session}"}
 
-    response = test_client.post('/dataset/file/upload/zip',
-                                data=data, headers=headers, content_type='multipart/form-data')
+    response = test_client.post(
+        "/dataset/file/upload/zip", data=data, headers=headers, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 400
 
@@ -623,10 +624,11 @@ def test_upload_no_file(test_client, login):
 
     data = {}
 
-    headers = {'Cookie': f'remember_token={remember_token}; session={session}'}
+    headers = {"Cookie": f"remember_token={remember_token}; session={session}"}
 
-    response = test_client.post('/dataset/file/upload/zip',
-                                data=data, headers=headers, content_type='multipart/form-data')
+    response = test_client.post(
+        "/dataset/file/upload/zip", data=data, headers=headers, content_type="multipart/form-data"
+    )
 
     assert response.status_code == 400
 
@@ -634,12 +636,15 @@ def test_upload_no_file(test_client, login):
 @pytest.fixture()
 def dataset_service():
     dataset_service = DataSetService()
-    with patch.object(dataset_service.dsmetadata_repository, 'create', return_value=DSMetaData(id=1)), \
-         patch.object(dataset_service.author_repository, 'create', return_value=Author(id=1)), \
-         patch.object(dataset_service.repository, 'create', return_value=DataSet(id=1)), \
-         patch.object(dataset_service.fmmetadata_repository, 'create', return_value=FMMetaData(id=1)), \
-         patch.object(dataset_service.feature_model_repository, 'create', return_value=FeatureModel(id=1)), \
-         patch.object(dataset_service.hubfilerepository, 'create', return_value=Hubfile(id=1)):
+    with patch.object(dataset_service.dsmetadata_repository, "create", return_value=DSMetaData(id=1)), patch.object(
+        dataset_service.author_repository, "create", return_value=Author(id=1)
+    ), patch.object(dataset_service.repository, "create", return_value=DataSet(id=1)), patch.object(
+        dataset_service.fmmetadata_repository, "create", return_value=FMMetaData(id=1)
+    ), patch.object(
+        dataset_service.feature_model_repository, "create", return_value=FeatureModel(id=1)
+    ), patch.object(
+        dataset_service.hubfilerepository, "create", return_value=Hubfile(id=1)
+    ):
 
         yield dataset_service
 
@@ -647,7 +652,7 @@ def dataset_service():
 @pytest.fixture()
 def current_user(dataset_service):
     profile = UserProfile(name="Jane", surname="Doe")
-    current_user = User(email='test@example.com', password='test1234', profile=profile)
+    current_user = User(email="test@example.com", password="test1234", profile=profile)
     yield current_user
 
 
@@ -655,43 +660,43 @@ def test_dsmetrics_with_whitespaces(dataset_service, current_user, test_app):
 
     with test_app.app_context():
         form = DataSetForm()
-        form.feature_models[0].uvl_filename.data = 'file_that_uses_whitespaces.uvl'
+        form.feature_models[0].uvl_filename.data = "file_that_uses_whitespaces.uvl"
 
-    with patch.object(current_user, 'temp_folder', return_value='app/modules/dataset/uvl_examples'), \
-         patch.object(dataset_service.dsmetrics_repository, 'create') as mock_create_dsmetrics:
+    with patch.object(current_user, "temp_folder", return_value="app/modules/dataset/uvl_examples"), patch.object(
+        dataset_service.dsmetrics_repository, "create"
+    ) as mock_create_dsmetrics:
         mock_create_dsmetrics.return_value = DSMetrics(id=1)
 
         dataset_service.create_from_form(form=form, current_user=current_user)
-        mock_create_dsmetrics.assert_called_once_with(number_of_models=1,
-                                                      number_of_features=10)
+        mock_create_dsmetrics.assert_called_once_with(number_of_models=1, number_of_features=10)
 
 
 def test_dsmetrics_with_tabs(dataset_service, current_user, test_app):
 
     with test_app.app_context():
         form = DataSetForm()
-        form.feature_models[0].uvl_filename.data = 'file_that_uses_tabs.uvl'
+        form.feature_models[0].uvl_filename.data = "file_that_uses_tabs.uvl"
 
-    with patch.object(current_user, 'temp_folder', return_value='app/modules/dataset/uvl_examples'), \
-         patch.object(dataset_service.dsmetrics_repository, 'create') as mock_create_dsmetrics:
+    with patch.object(current_user, "temp_folder", return_value="app/modules/dataset/uvl_examples"), patch.object(
+        dataset_service.dsmetrics_repository, "create"
+    ) as mock_create_dsmetrics:
         mock_create_dsmetrics.return_value = DSMetrics(id=1)
 
         dataset_service.create_from_form(form=form, current_user=current_user)
-        mock_create_dsmetrics.assert_called_once_with(number_of_models=1,
-                                                      number_of_features=24)
+        mock_create_dsmetrics.assert_called_once_with(number_of_models=1, number_of_features=24)
 
 
 def test_dsmetrics_both(dataset_service, current_user, test_app):
 
     with test_app.app_context():
         form = DataSetForm()
-        form.feature_models[0].uvl_filename.data = 'file_that_uses_whitespaces.uvl'
-        form.feature_models.append_entry(data={'uvl_filename': 'file_that_uses_tabs.uvl'})
+        form.feature_models[0].uvl_filename.data = "file_that_uses_whitespaces.uvl"
+        form.feature_models.append_entry(data={"uvl_filename": "file_that_uses_tabs.uvl"})
 
-    with patch.object(current_user, 'temp_folder', return_value='app/modules/dataset/uvl_examples'), \
-         patch.object(dataset_service.dsmetrics_repository, 'create') as mock_create_dsmetrics:
+    with patch.object(current_user, "temp_folder", return_value="app/modules/dataset/uvl_examples"), patch.object(
+        dataset_service.dsmetrics_repository, "create"
+    ) as mock_create_dsmetrics:
         mock_create_dsmetrics.return_value = DSMetrics(id=1)
 
         dataset_service.create_from_form(form=form, current_user=current_user)
-        mock_create_dsmetrics.assert_called_once_with(number_of_models=2,
-                                                      number_of_features=34)
+        mock_create_dsmetrics.assert_called_once_with(number_of_models=2, number_of_features=34)

--- a/app/modules/dataset/tests/test_unit.py
+++ b/app/modules/dataset/tests/test_unit.py
@@ -1197,7 +1197,7 @@ def test_dsmetrics_both(dataset_service, current_user, test_app):
         dataset_service.create_from_form(form=form, current_user=current_user)
         mock_create_dsmetrics.assert_called_once_with(number_of_models=2, number_of_features=34)
 
-        
+
 # Caso: URL válida de GitHub con archivo ZIP
 def test_upload_github_valid_zip(test_client, login):
     remember_token, session = login  # Obtenemos el token de autenticación


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed download formats in download_all_dataset by removing unsupported JSON and AFM formats
- Improved UVL file naming to maintain original filename without _uvl.txt suffix
- Standardized string quotes to use double quotes consistently
- Cleaned up code formatting and reduced line wrapping for better readability
- Fixed imports and removed unused imports



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Fix download formats and code style improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/dataset/routes.py

<li>Removed JSON and AFM format support from download_all_dataset function<br> <li> Fixed file naming in UVL format downloads<br> <li> Code formatting improvements and line wrapping fixes<br> <li> Standardized string quotes to double quotes<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/77/files#diff-eae06d42747f4b8c6533d8ca1550e75c045ba215402980aac2fe13496dfce454">+113/-156</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information