### PR TITLE
Cambiar ruta del home en fakenodo

### DIFF
--- a/app/modules/fakenodo/routes.py
+++ b/app/modules/fakenodo/routes.py
@@ -2,6 +2,6 @@ from flask import render_template
 from app.modules.fakenodo import fakenodo_bp
 
 
-@fakenodo_bp.route('/fakenodo', methods=['GET'])
+@fakenodo_bp.route("/fakenodo", methods=["GET"])
 def home():
-    return render_template('fakenodo/index.html')
+    return render_template("fakenodo/index.html")

--- a/app/modules/fakenodo/routes.py
+++ b/app/modules/fakenodo/routes.py
@@ -2,6 +2,6 @@ from flask import render_template
 from app.modules.fakenodo import fakenodo_bp
 
 
-@fakenodo_bp.route('/', methods=['GET'])
+@fakenodo_bp.route('/fakenodo', methods=['GET'])
 def home():
     return render_template('fakenodo/index.html')


### PR DESCRIPTION
### **User description**
Cambiar la ruta del home en fakenodo para que no solape la de zenodo


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed route collision issue by changing fakenodo home route from '/' to '/fakenodo'
- Standardized string quotes in route definition from single to double quotes



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Update fakenodo home route path and string formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/fakenodo/routes.py

<li>Changed route path from '/' to '/fakenodo' to avoid route collision <br>with zenodo<br> <li> Updated string quotes from single to double quotes for consistency<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/87/files#diff-e24b9953885507793f3cf2e8c63142d4510edafd6be9009ae2901b2227532003">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information