### PR TITLE
Cambiar entrada de secretos en workflow de despliegue en docker

### DIFF
--- a/.github/workflows/deployment_on_dockerhub.yml
+++ b/.github/workflows/deployment_on_dockerhub.yml
@@ -33,16 +33,11 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        run: docker build --build-arg VERSION_TAG=${{ github.event.release.tag_name }} -t drorganvidez/uvlhub:${{ github.event.release.tag_name }} -f docker/images/Dockerfile.prod .
+        run: docker build -t ignaciocefis/porra-hub:latest -f docker/images/Dockerfile.prod .
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled
 
       - name: Push Docker image to Docker Hub
-        run: docker push drorganvidez/uvlhub:${{ github.event.release.tag_name }}
-
-      - name: Tag and push latest
-        run: |
-          docker tag drorganvidez/uvlhub:${{ github.event.release.tag_name }} drorganvidez/uvlhub:latest
-          docker push drorganvidez/uvlhub:latest
+        run: docker push ignaciocefis/porra-hub:latest
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Modified Docker Hub deployment workflow to use new repository name `ignaciocefis/porra-hub`
- Simplified deployment process by:
  - Removing version-specific tagging
  - Using only 'latest' tag for Docker images
  - Consolidating build and push commands
- Maintained existing Docker authentication and environment configuration



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment_on_dockerhub.yml</strong><dd><code>Update Docker deployment workflow configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deployment_on_dockerhub.yml

<li>Updated Docker image name from <code>drorganvidez/uvlhub</code> to <br><code>ignaciocefis/porra-hub</code><br> <li> Simplified Docker build and push commands by removing version tagging<br> <li> Changed to use only 'latest' tag instead of version-specific tags<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/98/files#diff-ad98de20264755803ba4456ccee5783966f799791855ab4e2b46ab8dad62c761">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information