### PR TITLE
Formato de descarga de todos los datasets

### DIFF
--- a/app/modules/dataset/routes.py
+++ b/app/modules/dataset/routes.py
@@ -632,7 +632,7 @@ def download_all_dataset():
                                 GlencoeWriter(temp_file.name, fm).transform()
                                 with open(temp_file.name, "r") as new_format_file:
                                     content = new_format_file.read()
-                                name = f"{hubfile.name}_glencoe.txt"
+                                name = f"{hubfile.name}.glencoe"
                             elif format == "dimacs":
                                 temp_file = tempfile.NamedTemporaryFile(suffix=".cnf", delete=False)
                                 fm = UVLReader(hubfile.get_path()).transform()
@@ -640,18 +640,18 @@ def download_all_dataset():
                                 DimacsWriter(temp_file.name, sat).transform()
                                 with open(temp_file.name, "r") as new_format_file:
                                     content = new_format_file.read()
-                                name = f"{hubfile.name}_cnf.txt"
+                                name = f"{hubfile.name}.cnf"
                             elif format == "splot":
                                 temp_file = tempfile.NamedTemporaryFile(suffix=".splx", delete=False)
                                 fm = UVLReader(hubfile.get_path()).transform()
                                 SPLOTWriter(temp_file.name, fm).transform()
                                 with open(temp_file.name, "r") as new_format_file:
                                     content = new_format_file.read()
-                                name = f"{hubfile.name}_splot.txt"
+                                name = f"{hubfile.name}.splot"
                             elif format == "uvl":
                                 # Para UVL no hacemos transformación adicional, solo agregamos el archivo original
                                 content = open(full_path, "r").read()
-                                name = f"{file.name}.txt"
+                                name = f"{file.name}"
 
                             # Agregar el archivo convertido al ZIP en la carpeta correspondiente al dataset
                             zipf.writestr(os.path.join(dataset_folder, name), content)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed incorrect file extensions when downloading datasets in different formats:
  - Changed '.txt' to '.glencoe' for Glencoe format
  - Changed '_cnf.txt' to '.cnf' for DIMACS format
  - Changed '_splot.txt' to '.splot' for SPLOT format
  - Removed '.txt' suffix for UVL format files
- Improved consistency in file naming across all supported formats
- Ensures proper file recognition by external tools



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routes.py</strong><dd><code>Fix dataset download file extensions and naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/modules/dataset/routes.py

<li>Fixed file extension naming for different dataset formats (glencoe, <br>dimacs, splot, uvl)<br> <li> Removed redundant '_format.txt' suffixes and replaced with proper <br>format extensions<br> <li> Maintained original filename for UVL format without adding .txt <br>extension<br>


</details>


  </td>
  <td><a href="https://github.com/EGC-Porra-23-24/porra-hub/pull/100/files#diff-eae06d42747f4b8c6533d8ca1550e75c045ba215402980aac2fe13496dfce454">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information